### PR TITLE
feat(language-marko): add atom client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "clients/atom"]
+	path = clients/atom
+	url = git@github.com:marko-js/atom-language-marko.git

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Server implementation can be found [here](server).
 
 ### Atom
 
-- Marko has an [official plugin for Atom](https://github.com/marko-js/atom-language-marko) not based on the Language Server.
+- install [`language-marko`](https://atom.io/packages/language-marko) from the atom package registry ([plugin source](clients/atom))
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
     "vsce": "^1.85.0"
   },
   "scripts": {
-    "build": "tsc -b ./server ./clients/vscode",
+    "build": "tsc -b ./server ./clients/vscode ./clients/atom",
     "format": "prettier \"**/*.{ts,js,json,md}\" --write",
-    "lint": "tsc -p ./server --noEmit && tsc -p ./clients/vscode --noEmit && tslint -t codeFrame -c tslint.json '{server,clients/*}/src/**/*.ts'",
+    "lint": "tsc -p ./server --noEmit && tsc -p ./clients/vscode --noEmit && tsc -p ./clients/atom --noEmit && tslint -t codeFrame -c tslint.json '{server,clients/*}/src/**/*.ts'",
     "postinstall": "lerna bootstrap --hoist",
-    "postpublish": "(cd ./clients/vscode && npm i && vsce publish)",
+    "postpublish": "npm run publish:atom && npm run publish:vscode",
+    "publish:atom": "(cd ./clients/atom && npm i && apm publish)",
+    "publish:vscode": "(cd ./clients/vscode && npm i && vsce publish)",
     "publish": "npm run build && lerna publish",
     "watch": "npm run build -- -w"
   }


### PR DESCRIPTION
## Scope

language-marko

## Description

Adds the updated `language-marko` plugin (converted to use atom-languageclient).

## Checklist:

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
