### PR TITLE
fix: vscode engine version

### DIFF
--- a/.changeset/curvy-sloths-think.md
+++ b/.changeset/curvy-sloths-think.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Fix vscode engine version.

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -68,7 +68,7 @@
   },
   "displayName": "Marko VSCode",
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.66.0"
   },
   "homepage": "https://github.com/marko-js/language-server/tree/master/clients/vscode/README.md",
   "icon": "img/marko.png",


### PR DESCRIPTION
## Description

A previous dependency upgrade caused the vscode engine version to be out of sync. This PR upgrades it properly.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
