### PR TITLE
fix(marko-vscode): highlighting for manual .css extension on style blocks

### DIFF
--- a/.changeset/strong-phones-hide.md
+++ b/.changeset/strong-phones-hide.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Fix issue with manual css extenion on style block

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -8,12 +8,13 @@
       "comment": "CSS style block, eg: style { color: green }",
       "name": "meta.embedded.css",
       "contentName": "source.css",
-      "begin": "^\\s*(style)\\s+({)",
+      "begin": "^\\s*(style)(\\b[^\\s]*\\.css)?\\s+({)",
       "end": "}",
       "patterns": [{ "include": "source.css" }],
       "beginCaptures": {
         "1": { "name": "support.type.builtin.marko" },
-        "2": { "name": "punctuation.section.scope.begin.marko.css" }
+        "2": { "name": "storage.modifier.marko.css" },
+        "3": { "name": "punctuation.section.scope.begin.marko.css" }
       },
       "endCaptures": {
         "0": { "name": "punctuation.section.scope.end.marko.css" }


### PR DESCRIPTION
## Scope

marko-vscode

## Description

Fix highlighting for manual .css extension on style blocks, eg `style.module.css { /* ... */ } `.


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
