### PR TITLE
fix: incorrect highlighting as builtin tag for some custom tags

### DIFF
--- a/.changeset/polite-hairs-arrive.md
+++ b/.changeset/polite-hairs-arrive.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Fix issue with builtin tag highlighting when tag name followed by :, - or @.

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -922,7 +922,7 @@
                 {
                   "comment": "Core tag.",
                   "name": "support.function.marko",
-                  "match": "(for|if|while|else-if|else|macro|tag|await|try|async|let|const|effect|set|get|id|lifecycle)(?=\\b)"
+                  "match": "(for|if|while|else-if|else|macro|tag|await|try|async|let|const|effect|set|get|id|lifecycle)(?=\\b)(?![-:@])"
                 },
                 {
                   "comment": "Attribute tag.",


### PR DESCRIPTION
## Scope

marko-vscode

## Description

Fixes an issue where tags that were prefixed with builtin tag names were being highlighted as builtin tags, eg `<for-virtualized>`

## Checklist:

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
