### PR TITLE
Syntax highlighting improvements 05 10 2020

### DIFF
--- a/.changeset/clever-points-grin.md
+++ b/.changeset/clever-points-grin.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Fix issue with unary expressions (eg typeof) in attribute values that were part of a member expression (eg input.typeof) incorrectly highlighting

--- a/.changeset/olive-sloths-sell.md
+++ b/.changeset/olive-sloths-sell.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Improve attribute value highlighting when the value is unenclosed and spans multiple lines

--- a/.changeset/thin-jobs-joke.md
+++ b/.changeset/thin-jobs-joke.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Make concise mode html delimiters more visible.

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -104,7 +104,7 @@
           "name": "meta.marko-spread-attribute",
           "contentName": "source.ts",
           "begin": "(?:\\s+|,|(?<=\\[))(\\.\\.\\.)",
-          "end": "(?=$|[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
+          "end": "(?=$|[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
           "patterns": [{ "include": "#javascript-expression" }],
           "beginCaptures": {
             "1": { "name": "keyword.operator.spread.marko" }
@@ -126,7 +126,7 @@
       "name": "meta.embedded.ts",
       "contentName": "source.ts",
       "begin": "\\s*(:?=)\\s*",
-      "end": "(?=$|[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
+      "end": "(?=$|[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
       "patterns": [{ "include": "#javascript-expression" }],
       "beginCaptures": {
         "1": { "patterns": [{ "include": "source.ts" }] }
@@ -706,7 +706,7 @@
             {
               "comment": "Match type",
               "begin": "\\s*:(?!=)",
-              "end": "(?=$|[,;\\](]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
+              "end": "(?=$|[,;\\](]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
               "patterns": [
                 { "include": "source.ts#type" },
                 { "include": "#javascript-expression" }

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -87,7 +87,7 @@
           "comment": "Attribute with optional value",
           "name": "meta.marko-attribute",
           "applyEndPatternLast": 1,
-          "begin": "(?:\\s+|,|(?<=\\[))(?:(key|on[a-zA-Z0-9_$-]+|[a-zA-Z0-9_$]+Change|no-update(?:-body)?(?:-if)?)|([a-zA-Z0-9_$][a-zA-Z0-9_$-]*))(:[a-zA-Z0-9_$][a-zA-Z0-9_$-]*)?",
+          "begin": "(?:(key|on[a-zA-Z0-9_$-]+|[a-zA-Z0-9_$]+Change|no-update(?:-body)?(?:-if)?)|([a-zA-Z0-9_$][a-zA-Z0-9_$-]*))(:[a-zA-Z0-9_$][a-zA-Z0-9_$-]*)?",
           "end": "(?=.|$)",
           "beginCaptures": {
             "1": { "name": "support.type.attribute-name.marko" },
@@ -103,8 +103,8 @@
           "comment": "A ...spread attribute",
           "name": "meta.marko-spread-attribute",
           "contentName": "source.ts",
-          "begin": "(?:\\s+|,|(?<=\\[))(\\.\\.\\.)",
-          "end": "(?=$|[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
+          "begin": "(\\.\\.\\.)",
+          "end": "(?=[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
           "patterns": [{ "include": "#javascript-expression" }],
           "beginCaptures": {
             "1": { "name": "keyword.operator.spread.marko" }
@@ -126,7 +126,7 @@
       "name": "meta.embedded.ts",
       "contentName": "source.ts",
       "begin": "\\s*(:?=)\\s*",
-      "end": "(?=$|[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
+      "end": "(?=[,;\\]]|/>|(?<=[^>=])>[^>=]|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
       "patterns": [{ "include": "#javascript-expression" }],
       "beginCaptures": {
         "1": { "patterns": [{ "include": "source.ts" }] }
@@ -192,6 +192,10 @@
       "end": "]",
       "patterns": [
         { "include": "#concise-attr-group" },
+        {
+          "begin": "\\s+",
+          "end": "(?=\\S)"
+        },
         { "include": "#attrs" },
         { "include": "#invalid" }
       ],
@@ -214,6 +218,10 @@
           "patterns": [
             { "include": "#concise-semi-eol" },
             { "include": "#concise-attr-group" },
+            {
+              "begin": "[ \\t]+",
+              "end": "(?=\\S)"
+            },
             { "include": "#attrs" },
             { "include": "#invalid" }
           ]
@@ -582,7 +590,6 @@
         "2": { "name": "entity.name.tag.marko" }
       }
     },
-    "html-string-attrs": {},
     "invalid": {
       "comment": "Used to highlight characters in places where all valid characters should have been matched.",
       "match": "\\S",
@@ -639,7 +646,7 @@
         { "include": "#tag-before-attrs" },
         {
           "comment": "Attributes begin after the first space within the tag name",
-          "begin": "(?= )",
+          "begin": "(?=\\s)",
           "end": "(?=/?>)",
           "patterns": [{ "include": "#attrs" }]
         }
@@ -706,7 +713,7 @@
             {
               "comment": "Match type",
               "begin": "\\s*:(?!=)",
-              "end": "(?=$|[,;\\](]|/>|(?<=[^>=])>[^>=]|(?<![!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^-]-|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s+(?![{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>]))",
+              "end": "(?=[,;\\](]|/>|(?<=[^>=])>[^>=]|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
               "patterns": [
                 { "include": "source.ts#type" },
                 { "include": "#javascript-expression" }
@@ -715,7 +722,6 @@
             { "include": "#javascript-expression" }
           ]
         },
-        { "include": "#attr-value" },
         {
           "comment": "Parameters for a tag",
           "contentName": "source.ts",
@@ -732,7 +738,8 @@
             { "include": "source.ts" }
           ]
         },
-        { "include": "#html-args-or-method" }
+        { "include": "#html-args-or-method" },
+        { "include": "#attr-value" }
       ]
     },
     "tag-html": {

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -139,18 +139,18 @@
       "end": "\\1",
       "patterns": [{ "include": "#content-html-mode" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.section.scope.end.marko" }
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-html-line": {
       "comment": "-- HTML line within concise mode content. (content-html-mode w/o scriptlet)",
       "name": "meta.section.marko-html-line",
-      "match": "\\s*(--+)(?=\\s+\\S)(.*$)",
+      "match": "\\s*(--+)(?=\\s+\\S)(.*)($)",
       "captures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" },
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" },
         "2": {
           "patterns": [
             { "include": "#cdata" },
@@ -170,7 +170,8 @@
               "match": ".+?"
             }
           ]
-        }
+        },
+        "3": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-semi-eol": {
@@ -235,10 +236,10 @@
       "end": "\\1",
       "patterns": [{ "include": "#content-embedded-comment" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.section.scope.end.marko" }
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-comment-line": {
@@ -249,9 +250,11 @@
       "end": "$",
       "patterns": [{ "include": "#content-embedded-comment" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
-      "endCaptures": { "0": { "name": "punctuation.section.scope.end.marko" } }
+      "endCaptures": {
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
+      }
     },
     "concise-script-block": {
       "comment": "--- Embedded concise script content block. ---",
@@ -260,10 +263,10 @@
       "end": "\\1",
       "patterns": [{ "include": "#content-embedded-script" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.section.scope.end.marko" }
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-script-line": {
@@ -274,9 +277,11 @@
       "end": "$",
       "patterns": [{ "include": "#content-embedded-script" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
-      "endCaptures": { "0": { "name": "punctuation.section.scope.end.marko" } }
+      "endCaptures": {
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
+      }
     },
     "concise-style-block": {
       "comment": "--- Embedded concise style content block. ---",
@@ -286,10 +291,10 @@
       "end": "\\1",
       "patterns": [{ "include": "#content-embedded-style" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.section.scope.end.marko" }
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-style-block-less": {
@@ -300,10 +305,10 @@
       "end": "\\1",
       "patterns": [{ "include": "#content-embedded-style-less" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.section.scope.end.marko" }
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-style-block-scss": {
@@ -314,10 +319,10 @@
       "end": "\\1",
       "patterns": [{ "include": "#content-embedded-style-scss" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
       "endCaptures": {
-        "0": { "name": "punctuation.section.scope.end.marko" }
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
       }
     },
     "concise-style-line": {
@@ -329,9 +334,11 @@
       "end": "$",
       "patterns": [{ "include": "#content-embedded-style" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
-      "endCaptures": { "0": { "name": "punctuation.section.scope.end.marko" } }
+      "endCaptures": {
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
+      }
     },
     "concise-style-line-less": {
       "comment": "-- Embedded concise style content line.",
@@ -342,9 +349,11 @@
       "end": "$",
       "patterns": [{ "include": "#content-embedded-style-less" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
-      "endCaptures": { "0": { "name": "punctuation.section.scope.end.marko" } }
+      "endCaptures": {
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
+      }
     },
     "concise-style-line-scss": {
       "comment": "-- Embedded concise style content line.",
@@ -355,9 +364,11 @@
       "end": "$",
       "patterns": [{ "include": "#content-embedded-style-scss" }],
       "beginCaptures": {
-        "1": { "name": "punctuation.section.scope.begin.marko" }
+        "1": { "name": "punctuation.section.embedded.scope.begin.marko" }
       },
-      "endCaptures": { "0": { "name": "punctuation.section.scope.end.marko" } }
+      "endCaptures": {
+        "0": { "name": "punctuation.section.embedded.scope.end.marko" }
+      }
     },
     "content-concise-mode": {
       "comment": "Concise mode content block.",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

marko-vscode

## Description
* Fix issue with unary expressions (eg typeof) in attribute values that were part of a member expression (eg input.typeof) incorrectly highlighting
* Improve attribute value highlighting when the value is unenclosed and spans multiple lines
* Make concise mode html delimiters more visible.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
