### PR TITLE
fix: improve syntax highlighting

### DIFF
--- a/.changeset/swift-carrots-smoke.md
+++ b/.changeset/swift-carrots-smoke.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Improve highlighting, including concise mode identation tracking, fix issue with commas after attrs and fix cdata/doctype in some cases.

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -113,7 +113,7 @@
         {
           "comment": "Consume any whitespace after a comma",
           "begin": "\\s*(,(?!,))",
-          "end": "(?!\\S)",
+          "end": "(?=\\S)",
           "captures": {
             "1": { "name": "punctuation.separator.comma.marko" }
           }
@@ -214,14 +214,14 @@
         { "include": "#concise-semi-eol" },
         {
           "comment": "Matches unenclosed concise mode attributes.",
-          "begin": "(?!^)(?= )",
-          "end": "(?=--)|(?<!,)(?=\\n)",
+          "begin": "(?!^)[ \\t]",
+          "end": "(?=--)|(?=\\n)",
           "patterns": [
             { "include": "#concise-semi-eol" },
             { "include": "#concise-attr-group" },
             {
               "begin": "[ \\t]+",
-              "end": "(?=\\S)"
+              "end": "(?=\\S|\\n)"
             },
             { "include": "#attrs" },
             { "include": "#invalid" }
@@ -448,7 +448,7 @@
             },
             {
               "comment": "Normal concise tag",
-              "begin": "^\\s*(?=[a-zA-Z0-9_$@.#])",
+              "begin": "^([ \\t]*)(?=[a-zA-Z0-9_$@.#])",
               "while": "(?=^\\1\\s+(\\S|$))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
@@ -545,7 +545,7 @@
     "cdata": {
       "name": "meta.tag.metadata.cdata.marko",
       "contentName": "string.other.inline-data.marko",
-      "begin": "<!\\[CDATA\\[",
+      "begin": "\\s*<!\\[CDATA\\[",
       "end": "]]>",
       "beginCaptures": {
         "0": { "name": "punctuation.definition.tag.begin.marko" }
@@ -556,7 +556,7 @@
     },
     "doctype": {
       "name": "meta.tag.metadata.doctype.marko",
-      "begin": "<!(?=(?i:DOCTYPE\\s))",
+      "begin": "\\s*<!(?=(?i:DOCTYPE\\s))",
       "end": ">",
       "patterns": [
         {
@@ -657,7 +657,7 @@
         { "include": "#tag-before-attrs" },
         {
           "comment": "Attributes begin after the first space within the tag name",
-          "begin": "(?=\\s)",
+          "begin": "(?!/?>)",
           "end": "(?=/?>)",
           "patterns": [{ "include": "#attrs" }]
         }
@@ -723,12 +723,15 @@
             { "include": "source.ts#destructuring-variable" },
             {
               "comment": "Match type",
-              "begin": "\\s*:(?!=)",
+              "begin": "\\s*(:)(?!=)",
               "end": "(?=[,;\\](]|/>|(?<=[^>=])>[^>=]|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
               "patterns": [
                 { "include": "source.ts#type" },
                 { "include": "#javascript-expression" }
-              ]
+              ],
+              "beginCaptures": {
+                "1": { "name": "keyword.operator.type.annotation.ts" }
+              }
             },
             { "include": "#javascript-expression" }
           ]


### PR DESCRIPTION
## Scope

marko-vscode

## Description

Improves a few issues with syntax highlighting:
* Concise mode was not always properly tracking indentation.
* Comas after attributes were not always honored, especially after the default attribute.
* CDATA/Doctype were not always highlighting (normal comment was taking priority).
* Incorrect token type for tag variable type colon.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
