### PR TITLE
feat: show error highlighting on extra close tags

### DIFF
--- a/.changeset/clean-schools-relax.md
+++ b/.changeset/clean-schools-relax.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Add error highlighting when an extraneous html closing tag is found

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -382,6 +382,7 @@
         { "include": "#html-comment" },
         { "include": "#concise-html-block" },
         { "include": "#concise-html-line" },
+        { "include": "#invalid-close-tag" },
         { "include": "#tag-html" },
         {
           "comment": "A concise html tag.",
@@ -503,6 +504,7 @@
         { "include": "#doctype" },
         { "include": "#declaration" },
         { "include": "#html-comment" },
+        { "include": "#invalid-close-tag" },
         { "include": "#tag-html" },
         { "match": "\\\\.", "name": "text.marko" },
         { "include": "#placeholder" },
@@ -1040,6 +1042,11 @@
           ]
         }
       ]
+    },
+    "invalid-close-tag": {
+      "name": "invalid.illegal.character-not-allowed-here.marko",
+      "begin": "\\s*</.*?",
+      "end": ">"
     }
   }
 }


### PR DESCRIPTION
## Description

Add error highlighting when an extraneous html closing tag is found

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
