### PR TITLE
fix: better support bracket colorization

### DIFF
--- a/.changeset/silent-wombats-hang.md
+++ b/.changeset/silent-wombats-hang.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Better support bracket colorization.

--- a/clients/vscode/syntaxes/marko.tmLanguage.json
+++ b/clients/vscode/syntaxes/marko.tmLanguage.json
@@ -392,7 +392,7 @@
             {
               "comment": "Concise Marko html-comment tag",
               "begin": "^(\\s*)(?=html-comment\\b)",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#concise-comment-block" },
@@ -402,7 +402,7 @@
             {
               "comment": "Concise style tag less",
               "begin": "^(\\s*)(?=style\\b[^\\s]*\\.less\\b)",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#concise-style-block-less" },
@@ -412,7 +412,7 @@
             {
               "comment": "Concise style tag scss",
               "begin": "^(\\s*)(?=style\\b[^\\s]*\\.scss\\b)",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#concise-style-block-scss" },
@@ -422,7 +422,7 @@
             {
               "comment": "Concise style tag js/ts",
               "begin": "^(\\s*)(?=style\\b[^\\s]*\\.[tj]s\\b)",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#concise-script-block" },
@@ -432,7 +432,7 @@
             {
               "comment": "Concise style tag",
               "begin": "^(\\s*)(?=style\\b)",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#concise-style-block" },
@@ -442,7 +442,7 @@
             {
               "comment": "Concise script tag",
               "begin": "^(\\s*)(?=script\\b)",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#concise-script-block" },
@@ -452,7 +452,7 @@
             {
               "comment": "Normal concise tag",
               "begin": "^([ \\t]*)(?=[a-zA-Z0-9_$@.#])",
-              "while": "(?=^\\1\\s+(\\S|$))",
+              "while": "(?=^(?:[})\\]`]|*/|\\1\\s+(\\S|$)))",
               "patterns": [
                 { "include": "#concise-open-tag-content" },
                 { "include": "#content-concise-mode" }


### PR DESCRIPTION
## Description

Fixes an issue with concise tags being exited too early by the highlight grammar which ultimately broke bracket colorization.
Resolves #83 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
