### PR TITLE
Document highlights provider

### DIFF
--- a/.changeset/clever-gorillas-laugh.md
+++ b/.changeset/clever-gorillas-laugh.md
@@ -1,0 +1,6 @@
+---
+"marko-vscode": patch
+"@marko/language-server": patch
+---
+
+Implements document highlight provider (currently for stylesheets).

--- a/clients/vscode/src/__tests__/colors.test.ts
+++ b/clients/vscode/src/__tests__/colors.test.ts
@@ -1,0 +1,39 @@
+import vscode from "vscode";
+import snap from "mocha-snap";
+import { getTestDoc, updateTestDoc } from "./setup.test";
+
+describe("document color", () => {
+  it("css color", async () => {
+    await snap.inline(
+      () =>
+        documentColor(
+          `style {
+  body {
+    color: blue;
+  }
+}`
+        ),
+      `rgb(0, 0, 255)
+#0000ff
+hsl(240, 100%, 50%)
+hwb(240 0% 0%)`
+    );
+  });
+});
+
+async function documentColor(src: string) {
+  const doc = getTestDoc();
+  await updateTestDoc(src);
+  const [info] = await vscode.commands.executeCommand<
+    vscode.ColorInformation[]
+  >("vscode.executeDocumentColorProvider", doc.uri);
+
+  const presentations = await vscode.commands.executeCommand<
+    vscode.ColorPresentation[]
+  >("vscode.executeColorPresentationProvider", info.color, {
+    uri: doc.uri,
+    range: info.range,
+  });
+
+  return presentations.map((it) => it.label).join("\n");
+}

--- a/clients/vscode/src/__tests__/highlight.test.ts
+++ b/clients/vscode/src/__tests__/highlight.test.ts
@@ -1,0 +1,50 @@
+import vscode from "vscode";
+import snap from "mocha-snap";
+import { getTestDoc, getTestEditor, updateTestDoc } from "./setup.test";
+
+describe("document highlight", () => {
+  it("css class selector", async () => {
+    await snap.inline(
+      () =>
+        documentHighlight(
+          `style {
+  .test█ {
+    color: blue;
+  }
+
+  .test {
+    display: none;
+  }
+}`
+        ),
+      `[
+  {
+    kind: 2,
+    offset: 10,
+    value: '.test'
+  },
+  {
+    kind: 2,
+    offset: 42,
+    value: '.test'
+  },
+  [length]: 2
+]`
+    );
+  });
+});
+
+async function documentHighlight(src: string) {
+  const doc = getTestDoc();
+  const editor = getTestEditor();
+  await updateTestDoc(src);
+  const highlights = await vscode.commands.executeCommand<
+    vscode.DocumentHighlight[]
+  >("vscode.executeDocumentHighlights", doc.uri, editor.selection.start);
+
+  return highlights.map((it) => ({
+    offset: doc.offsetAt(it.range.start),
+    value: doc.getText(it.range),
+    kind: it.kind,
+  }));
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,6 +47,7 @@ connection.onInitialize(() => {
       renameProvider: true,
       codeActionProvider: true,
       colorProvider: true,
+      documentHighlightProvider: true,
       completionProvider: {
         triggerCharacters: [
           ".",
@@ -99,6 +100,16 @@ connection.onDefinition(async (params, cancel) => {
       params,
       cancel
     )) as DefinitionLink[]) || null
+  );
+});
+
+connection.onDocumentHighlight(async (params, cancel) => {
+  return (
+    (await service.findDocumentHighlights(
+      documents.get(params.textDocument.uri)!,
+      params,
+      cancel
+    )) || null
   );
 });
 

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -7,6 +7,7 @@ import {
   CompletionList,
   DefinitionLink,
   Diagnostic,
+  DocumentHighlight,
   Location,
   WorkspaceEdit,
 } from "vscode-languageserver";
@@ -65,6 +66,30 @@ const service: Plugin = {
             result.push(...cur);
           } else {
             result.push(cur);
+          }
+        }
+      }
+    } catch (err) {
+      displayError(err);
+    }
+
+    return result;
+  },
+  async findDocumentHighlights(doc, params, cancel) {
+    let result: DocumentHighlight[] | undefined;
+
+    try {
+      const requests = plugins.map((plugin) =>
+        plugin.findDocumentHighlights?.(doc, params, cancel)
+      );
+      for (const pending of requests) {
+        const cur = await pending;
+        if (cancel.isCancellationRequested) return;
+        if (cur) {
+          if (result) {
+            result.push(...cur);
+          } else {
+            result = cur;
           }
         }
       }

--- a/server/src/service/types.ts
+++ b/server/src/service/types.ts
@@ -13,6 +13,8 @@ import type {
   Diagnostic,
   DocumentColorParams,
   DocumentFormattingParams,
+  DocumentHighlight,
+  DocumentHighlightParams,
   Hover,
   HoverParams,
   Location,
@@ -40,6 +42,7 @@ export type Plugin = {
     DefinitionParams,
     Location | LocationLink | (Location | LocationLink)[]
   >;
+  findDocumentHighlights: Handler<DocumentHighlightParams, DocumentHighlight[]>;
   findDocumentColors: Handler<DocumentColorParams, ColorInformation[]>;
   getColorPresentations: Handler<ColorPresentationParams, ColorPresentation[]>;
   format: Handler<DocumentFormattingParams, TextEdit[]>;


### PR DESCRIPTION
## Description

Implements document highlight provider (currently for stylesheets).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
