### PR TITLE
fix: enable formatter as a default config option

### DIFF
--- a/.changeset/rare-suns-remain.md
+++ b/.changeset/rare-suns-remain.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Enable Marko's formatter by default without needing to specify it in your vscode config.

--- a/clients/vscode/package.json
+++ b/clients/vscode/package.json
@@ -57,6 +57,11 @@
           "description": "Traces the communication between VSCode and the language server."
         }
       }
+    },
+    "configurationDefaults": {
+      "[marko]": {
+        "editor.defaultFormatter": "Marko-JS.marko-vscode"
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

Enables the Marko formatter by default (no longer necessary to configure a default formatter for Marko files).
