### PR TITLE
fix: ts-plugin regression

### DIFF
--- a/.changeset/cold-kids-mix.md
+++ b/.changeset/cold-kids-mix.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix regression that caused ts-plugin to crash and a failure to resolve the internal Marko types.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
       "args": [
         "--disable-extensions",
         "--extensionDevelopmentPath=${workspaceFolder}/packages/vscode",
-        "${workspaceFolder}/packages/language-tools/src/__tests__/fixtures"
+        "/Users/dpiercey/dev/marko-js/tags-api-preview"
       ],
       "outFiles": [
         "${workspaceFolder}/**/dist/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "mocha-snap": "^4.3.0",
         "prettier": "^2.8.7",
         "tsx": "^3.12.6",
-        "typescript": "^5.0.2"
+        "typescript": "^5.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -54,28 +54,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.0.tgz",
-      "integrity": "sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
+      "integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
-      "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
+      "integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.3",
-        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
+        "@babel/helper-compilation-targets": "^7.21.4",
         "@babel/helper-module-transforms": "^7.21.2",
         "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.3",
+        "@babel/parser": "^7.21.4",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.3",
-        "@babel/types": "^7.21.3",
+        "@babel/traverse": "^7.21.4",
+        "@babel/types": "^7.21.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -110,11 +110,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.3.tgz",
-      "integrity": "sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
+      "integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
       "dependencies": {
-        "@babel/types": "^7.21.3",
+        "@babel/types": "^7.21.4",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -159,12 +159,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
-      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
+      "integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
       "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/compat-data": "^7.21.4",
+        "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
@@ -198,9 +198,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.0.tgz",
-      "integrity": "sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.21.4.tgz",
+      "integrity": "sha512-46QrX2CQlaFRF4TkwfTt6nJD7IHq8539cCL7SDpqWSDeJKY1xylKKY5F/33mJhLZ3mFvKv2gGrVS6NkyF6qs+Q==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -261,11 +261,11 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.21.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.3.tgz",
-      "integrity": "sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
+      "integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -419,11 +419,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
-      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz",
+      "integrity": "sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -490,18 +490,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.3.tgz",
-      "integrity": "sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
+      "integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.21.3",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.3",
-        "@babel/types": "^7.21.3",
+        "@babel/parser": "^7.21.4",
+        "@babel/types": "^7.21.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -518,9 +518,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.3.tgz",
-      "integrity": "sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
+      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -1588,9 +1588,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.76.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.76.0.tgz",
-      "integrity": "sha512-CQcY3+Fe5hNewHnOEAVYj4dd1do/QHliXaknAEYSXx2KEHUzFibDZSKptCon+HPgK55xx20pR+PBJjf0MomnBA==",
+      "version": "1.77.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.77.0.tgz",
+      "integrity": "sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3083,9 +3083,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.345",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.345.tgz",
-      "integrity": "sha512-znGhOQK2TUYLICgS25uaM0a7pHy66rSxbre7l762vg9AUoCcJK+Bu+HCPWpjL/U/kK8/Hf+6E0szAUJSyVYb3Q=="
+      "version": "1.4.348",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.348.tgz",
+      "integrity": "sha512-gM7TdwuG3amns/1rlgxMbeeyNoBFPa+4Uu0c7FeROWh4qWmvSOnvcslKmWy51ggLKZ2n/F/4i2HJ+PVNxH9uCQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -8318,9 +8318,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
+      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9003,7 +9003,7 @@
         "prettier-plugin-marko": "^1.4.1",
         "relative-import-path": "^1.0.0",
         "strip-json-comments": "^5.0.0",
-        "typescript": "^5.0.2",
+        "typescript": "^5.0.3",
         "vscode-css-languageservice": "^6.2.4",
         "vscode-languageserver": "^8.1.0",
         "vscode-languageserver-textdocument": "^1.0.8",
@@ -9033,14 +9033,14 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/parser": "^7.21.3",
+        "@babel/parser": "^7.21.4",
         "@marko/compiler": "5.27.4",
         "@marko/translator-default": "5.25.4",
         "htmljs-parser": "^5.4.3",
         "relative-import-path": "^1.0.0"
       },
       "devDependencies": {
-        "@babel/code-frame": "^7.18.6",
+        "@babel/code-frame": "^7.21.4",
         "@marko/compiler": "^5.27.4",
         "@types/babel__code-frame": "^7.0.3",
         "@types/babel__helper-validator-identifier": "^7.15.0",
@@ -9055,12 +9055,12 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
+        "@babel/code-frame": "^7.21.4",
         "@marko/language-tools": "^2.0.0",
         "arg": "^5.0.2",
         "kleur": "^4.1.5",
         "strip-json-comments": "^5.0.0",
-        "typescript": "5.0.2"
+        "typescript": "5.0.3"
       },
       "bin": {
         "marko-type-check": "dist/cli.js",
@@ -9072,8 +9072,7 @@
     },
     "packages/type-check/node_modules/strip-json-comments": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.0.tgz",
-      "integrity": "sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -9098,6 +9097,9 @@
       "engines": {
         "vscode": "^1.74.2"
       }
+    },
+    "packages/vscode/node_modules/marko-ts-plugin": {
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "mocha-snap": "^4.3.0",
     "prettier": "^2.8.7",
     "tsx": "^3.12.6",
-    "typescript": "^5.0.2"
+    "typescript": "^5.0.3"
   },
   "private": true,
   "scripts": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -18,7 +18,7 @@
     "prettier-plugin-marko": "^1.4.1",
     "relative-import-path": "^1.0.0",
     "strip-json-comments": "^5.0.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.0.3",
     "vscode-css-languageservice": "^6.2.4",
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8",

--- a/packages/language-server/src/ts-plugin/host.ts
+++ b/packages/language-server/src/ts-plugin/host.ts
@@ -3,12 +3,17 @@ import type ts from "typescript/lib/tsserverlibrary";
 import {
   type Extracted,
   Processors,
+  Project,
   getExt,
   isDefinitionFile,
 } from "@marko/language-tools";
 
 const fsPathReg = /^(?:[./\\]|[A-Z]:)/i;
 const modulePartsReg = /^((?:@(?:[^/]+)\/)?(?:[^/]+))(.*)$/;
+Project.setDefaultTypePaths({
+  internalTypesFile: path.join(__dirname, "marko.internal.d.ts"),
+  markoTypesFile: path.join(__dirname, "marko.runtime.d.ts"),
+});
 
 export interface ExtractedSnapshot extends Extracted {
   snapshot: ts.IScriptSnapshot;
@@ -80,7 +85,7 @@ export function patch(
 
         ps?.getOrCreateScriptInfoForNormalizedPath(
           fileName as any,
-          false,
+          true,
           undefined,
           ts.ScriptKind.Deferred,
           false,

--- a/packages/language-tools/package.json
+++ b/packages/language-tools/package.json
@@ -5,14 +5,14 @@
   "bugs": "https://github.com/marko-js/language-server/issues/new?template=Bug_report.md",
   "dependencies": {
     "@babel/helper-validator-identifier": "^7.19.1",
-    "@babel/parser": "^7.21.3",
+    "@babel/parser": "^7.21.4",
     "@marko/compiler": "5.27.4",
     "@marko/translator-default": "5.25.4",
     "htmljs-parser": "^5.4.3",
     "relative-import-path": "^1.0.0"
   },
   "devDependencies": {
-    "@babel/code-frame": "^7.18.6",
+    "@babel/code-frame": "^7.21.4",
     "@marko/compiler": "^5.27.4",
     "@types/babel__code-frame": "^7.0.3",
     "@types/babel__helper-validator-identifier": "^7.15.0",

--- a/packages/language-tools/src/util/project.ts
+++ b/packages/language-tools/src/util/project.ts
@@ -19,6 +19,15 @@ export interface Meta {
   };
 }
 
+interface TypeLibs {
+  internalTypesFile: string | undefined;
+  markoRunTypesFile: string | undefined;
+  markoRunGeneratedTypesFile: string | undefined;
+  markoTypesFile: string | undefined;
+  markoTypesCode: string | undefined;
+}
+
+const defaultTypeLibs: Partial<TypeLibs> = {};
 const ignoreErrors = (_err: Error) => {};
 const metaByDir = new Map<string, Meta>();
 const metaByCompiler = new Map<string, Meta>();
@@ -97,8 +106,11 @@ export function getTypeLibs(
       host
     );
 
-  const internalTypesFile = resolvedInternalTypes?.resolvedFileName;
-  const markoTypesFile = resolvedMarkoTypes?.resolvedFileName;
+  const internalTypesFile =
+    resolvedInternalTypes?.resolvedFileName ||
+    defaultTypeLibs.internalTypesFile;
+  const markoTypesFile =
+    resolvedMarkoTypes?.resolvedFileName || defaultTypeLibs.markoTypesFile;
   const markoRunTypesFile = resolvedMarkoRunTypes?.resolvedFileName;
 
   if (!internalTypesFile || !markoTypesFile) {
@@ -137,7 +149,11 @@ export function getScriptLang(
   let scriptLang = cache?.get(dir);
 
   if (!scriptLang) {
-    const configPath = ts.findConfigFile(dir, host.fileExists, "marko.json");
+    const configPath = ts.findConfigFile(
+      dir,
+      host.fileExists.bind(host),
+      "marko.json"
+    );
 
     if (configPath) {
       try {
@@ -182,6 +198,10 @@ export function clearCaches() {
   for (const project of metaByCompiler.values()) {
     clearCacheForMeta(project);
   }
+}
+
+export function setDefaultTypePaths(defaults: typeof defaultTypeLibs) {
+  Object.assign(defaultTypeLibs, defaults);
 }
 
 function getMeta(dir?: string): Meta {

--- a/packages/type-check/package.json
+++ b/packages/type-check/package.json
@@ -4,12 +4,12 @@
   "version": "0.0.1",
   "bugs": "https://github.com/marko-js/language-server/issues/new?template=Bug_report.md",
   "dependencies": {
-    "@babel/code-frame": "^7.18.6",
+    "@babel/code-frame": "^7.21.4",
     "@marko/language-tools": "^2.0.0",
     "arg": "^5.0.2",
     "kleur": "^4.1.5",
     "strip-json-comments": "^5.0.0",
-    "typescript": "5.0.2"
+    "typescript": "5.0.3"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.3"

--- a/packages/vscode/build.mts
+++ b/packages/vscode/build.mts
@@ -55,7 +55,14 @@ await Promise.all([
       "src/ts-plugin.ts",
       "src/__tests__/index.ts",
     ],
-    external: ["vscode", "mocha", "mocha-snap", "fast-glob", "tsx"],
+    external: [
+      "vscode",
+      "mocha",
+      "mocha-snap",
+      "fast-glob",
+      "tsx",
+      "@babel/preset-typescript",
+    ],
     plugins: [
       {
         name: "vscode-css-languageservice-fix",


### PR DESCRIPTION
## Description

* Fixes a regression where trying to resolve a Marko file in a typescript file would cause the ts language server to crash.

* Fixes a regression where the default Marko core/internal runtimes were not being loaded.
