### PR TITLE
feat: switch mtc to typescripts build mode api

### DIFF
--- a/.changeset/kind-goats-live.md
+++ b/.changeset/kind-goats-live.md
@@ -1,0 +1,8 @@
+---
+"@marko/type-check": major
+---
+
+Switch to using the build mode for the TypeScript compiler.
+This allows using [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) and incremental compilation.
+
+This change now requires that mtc output at least the files for caching and so the `--emit` flag has been removed and enabled by default.

--- a/.changeset/large-pugs-melt.md
+++ b/.changeset/large-pugs-melt.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/type-check": patch
+"@marko/language-server": patch
+"marko-vscode": patch
+---
+
+When considering if a Marko file should be parsed as typescript, it will now default to typescript for any file containing `tsconfig`. Previously this would exclusively match `tsconfig.json` which would fail with files like `tsconfig.build.json`.

--- a/packages/language-tools/src/processors/marko.ts
+++ b/packages/language-tools/src/processors/marko.ts
@@ -13,7 +13,7 @@ export default {
       ? host.getCurrentDirectory()
       : ts.sys.getCurrentDirectory();
     const defaultScriptLang =
-      configFile && /tsconfig.json$/.test(configFile)
+      configFile && /tsconfig/g.test(configFile)
         ? ScriptLang.ts
         : ScriptLang.js;
     const runtimeTypes = Project.getTypeLibs(currentDirectory, ts, host);

--- a/packages/type-check/README.md
+++ b/packages/type-check/README.md
@@ -25,7 +25,6 @@ mtc [options]
 | ---------------- | ----- | ---------------------------------------------------------------------- | ---------------------------------- |
 | --project <path> | -p    | Path to the tsconfig or jsconfig file                                  | ./tsconfig.json or ./jsconfig.json |
 | --display <type> | -d    | Set the display type for error output. Choices: codeframe or condensed | codeframe                          |
-| --emit           | -e    | Emit .js, .d.ts, .marko (with types stripped), and .d.marko files      | false                              |
 | --help           | -h    | Display the help text                                                  |                                    |
 | --version        | -v    | Display the CLI version, Marko version, and TypeScript version         |                                    |
 
@@ -43,17 +42,11 @@ marko-type-check
 mtc -p ./jsconfig.json -d condensed
 ```
 
-### Run type check and emit output files:
-
-```
-marko-type-check -e
-```
-
 ## FAQ
 
-### What files are emitted with the `--emit` option?
+### What files are emitted?
 
-The `emit` option outputs files similar to the [`tsc` cli](https://www.typescriptlang.org/docs/handbook/compiler-options.html). Meaning `.js` and `.d.ts` files will be output. Beyond that `.marko` files _with their types stripped_ and an associated `.d.marko` file will be output that serve a similar purpose to the `.js` and `.d.ts` files.
+Outputs files are similar to the [`tsc` cli in build mode](https://www.typescriptlang.org/docs/handbook/project-references.html). Meaning `.js` and `.d.ts` files will be output (depending on your project config). Beyond that `.marko` files _with their types stripped_ and an associated `.d.marko` file will be output that serve a similar purpose to the `.js` and `.d.ts` files.
 
 ### What is a `.d.marko` file?
 

--- a/packages/type-check/src/cli.ts
+++ b/packages/type-check/src/cli.ts
@@ -11,12 +11,10 @@ const args = arg(
   {
     "--project": String,
     "--display": String,
-    "--emit": Boolean,
     "--help": Boolean,
     "--version": Boolean,
     "-p": "--project",
     "-d": "--display",
-    "-e": "--emit",
     "-h": "--help",
     "-v": "--version",
   },
@@ -42,11 +40,6 @@ ${color.bold("Options:")}
   )}       Set the display type for error output. Choices: ${color.green(
     `"codeframe"`
   )} or ${color.green(`"condensed"`)} (default: ${color.green(`"codeframe"`)})
-  ${color.yellow(
-    "-e, --emit"
-  )}                 Emit .js, .d.ts, .marko (with types stripped), and .d.marko files (default: ${color.magenta(
-    "false"
-  )})
   ${color.yellow(
     "-v, --version"
   )}              Display the CLI version, Marko version, and TypeScript version
@@ -78,7 +71,6 @@ For more information, visit ${color.blue(
   );
 } else {
   const {
-    "--emit": emit,
     "--display": display = process.env.CI
       ? Display.condensed
       : Display.codeframe,
@@ -93,7 +85,7 @@ For more information, visit ${color.blue(
   }
 
   checkDisplay(display);
-  run({ project, display, emit });
+  run({ project, display });
 }
 
 function checkDisplay(


### PR DESCRIPTION
## Scope

Mostly this impacts `@marko/type-check`.

## Description

Switches `@marko/type-check` to use the incremental build apis from the typescript compiler.

## Motivation and Context

This means that you can now use [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) and also improve performance via caching and incremental builds.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
