### PR TITLE
fix(axe-core): add filter for false positive

### DIFF
--- a/.changeset/shiny-fishes-fix.md
+++ b/.changeset/shiny-fishes-fix.md
@@ -1,0 +1,6 @@
+---
+"@marko/language-server": patch
+"marko-vscode": patch
+---
+
+add new rule filter to a11y linter

--- a/packages/language-server/src/service/html/axe-rules/rule-exceptions.ts
+++ b/packages/language-server/src/service/html/axe-rules/rule-exceptions.ts
@@ -1,7 +1,7 @@
 import * as r from "./axe-rules";
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I
+  k: infer I,
 ) => void
   ? I
   : never;

--- a/packages/language-server/src/service/html/axe-rules/rule-exceptions.ts
+++ b/packages/language-server/src/service/html/axe-rules/rule-exceptions.ts
@@ -1,7 +1,7 @@
 import * as r from "./axe-rules";
 
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I,
+  k: infer I
 ) => void
   ? I
   : never;
@@ -67,7 +67,7 @@ export const ruleExceptions: { [id in Whitelist]: Exceptions } = {
   [r.aria.ariaProgressbarName]: { unknownBody: true, attrSpread: true },
   [r.aria.ariaRequiredAttr]: { attrSpread: true },
   [r.aria.ariaRequiredChildren]: { unknownBody: true },
-  [r.aria.ariaRoles]: {},
+  [r.aria.ariaRoles]: { dynamicAttrs: ["role"] },
   [r.aria.ariaText]: { unknownBody: true },
   [r.aria.ariaToggleFieldName]: { unknownBody: true, attrSpread: true },
   [r.aria.ariaTooltipName]: { unknownBody: true, attrSpread: true },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

<!-- Which package does this PR affect? -->

## Description

Added extra filter for the following false positive:
```marko
span role=someDynamicValue
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<img width="645" alt="image" src="https://github.com/marko-js/language-server/assets/26027232/b6d5094e-94b6-4323-b3ab-06a6913c6ebe">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
