### PR TITLE
feat: add .js extension for mtc output

### DIFF
--- a/.changeset/gorgeous-ducks-reflect.md
+++ b/.changeset/gorgeous-ducks-reflect.md
@@ -1,0 +1,6 @@
+---
+"@marko/language-tools": minor
+"@marko/type-check": minor
+---
+
+Automatically add `.js` extensions where necessary in files output by `@marko/type-check` to work better with native es modules.

--- a/packages/language-tools/src/processors/index.ts
+++ b/packages/language-tools/src/processors/index.ts
@@ -41,7 +41,7 @@ export interface PrintContext {
 
 export const extensions = [marko.extension] as ProcessorExtension[];
 
-export function create(options: Parameters<ProcessorConfig["create"]>[0]) {
+export function create(options: CreateProcessorOptions) {
   return {
     [marko.extension]: marko.create(options),
   } as Record<ProcessorExtension, Processor>;


### PR DESCRIPTION
## Description

When using `@marko/type-check` to emit js files for a native es module package the output files will not have the resolved extension included for relative imports.

This is actually a TypeScript design that they say is working as intended:
https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-specifiers-are-not-transformed

However besides being very strange to import non existing `.js` files, it also doesn't work in `jest`, `vite`, `vitest`, `webpack`, `rollup`, or `esbuild`.

So this PR handles it for you. With this change `.js` extensions are automatically added to output relative import paths.
