### PR TITLE
Extra marko run characters

### DIFF
--- a/.changeset/nasty-books-exercise.md
+++ b/.changeset/nasty-books-exercise.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix regex for component filenames

--- a/packages/language-tools/src/extractors/script/util/get-component-filename.ts
+++ b/packages/language-tools/src/extractors/script/util/get-component-filename.ts
@@ -8,7 +8,7 @@ export function getComponentFilename(from: string) {
     nameNoExt = nameNoExt.slice(0, -2);
   }
   const isEntry = nameNoExt === "index";
-  const fileMatch = `(${nameNoExt.replace(/\./g, "\\.")}\\.${
+  const fileMatch = `(${nameNoExt.replace(/[.*+?^$[\]()|\\:!{}]/g, "\\$&")}\\.${
     isEntry ? "|" : ""
   })`;
   const componentMatch = new RegExp(


### PR DESCRIPTION
- Fixes bug introduced in #244 when filename includes special regex characters (i. e. `+layout.marko`)