### PR TITLE
fix(html-extractor): remove modifiers

### DIFF
--- a/.changeset/red-starfishes-smell.md
+++ b/.changeset/red-starfishes-smell.md
@@ -1,0 +1,7 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"marko-vscode": patch
+---
+
+Ignore modifiers in html extractor

--- a/packages/language-server/src/__tests__/fixtures/html/alt-text/__snapshots__/alt-text.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/html/alt-text/__snapshots__/alt-text.expected/index.md
@@ -67,6 +67,7 @@
   Element has no title attribute
   17 |
   18 | <svg role="img"></svg>
+  19 |
 ```
 
 ### Ln 18, Col 2
@@ -79,5 +80,7 @@
   aria-label attribute does not exist or is empty
   aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
   Element has no title attribute
+  19 |
+  20 | <img alt:no-update="test" />
 ```
 

--- a/packages/language-server/src/__tests__/fixtures/html/alt-text/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/html/alt-text/index.marko
@@ -16,3 +16,5 @@
 <div role="img"></div>
 
 <svg role="img"></svg>
+
+<img alt:no-update="test" />

--- a/packages/language-tools/src/extractors/html/index.ts
+++ b/packages/language-tools/src/extractors/html/index.ts
@@ -115,7 +115,7 @@ class HTMLExtractor {
   #writeAttrNamed(attr: Node.AttrNamed) {
     this.#extractor.write(" ");
     const nameString = this.#read(attr.name);
-    if (nameString.includes(":")) {
+    if (nameString.endsWith(":scoped") || nameString.endsWith(":no-update")) {
       this.#extractor.copy({
         start: attr.name.start,
         end: attr.name.start + nameString.indexOf(":"),

--- a/packages/language-tools/src/extractors/html/index.ts
+++ b/packages/language-tools/src/extractors/html/index.ts
@@ -114,7 +114,15 @@ class HTMLExtractor {
 
   #writeAttrNamed(attr: Node.AttrNamed) {
     this.#extractor.write(" ");
-    this.#extractor.copy(attr.name);
+    const nameString = this.#read(attr.name);
+    if (nameString.includes(":")) {
+      this.#extractor.copy({
+        start: attr.name.start,
+        end: attr.name.start + nameString.indexOf(":"),
+      });
+    } else {
+      this.#extractor.copy(attr.name);
+    }
 
     if (
       attr.value === undefined ||

--- a/packages/language-tools/src/extractors/html/index.ts
+++ b/packages/language-tools/src/extractors/html/index.ts
@@ -115,10 +115,10 @@ class HTMLExtractor {
   #writeAttrNamed(attr: Node.AttrNamed) {
     this.#extractor.write(" ");
     const nameString = this.#read(attr.name);
-    if (nameString.endsWith(":scoped") || nameString.endsWith(":no-update")) {
+    if (/:(?:scoped|(?:no-update(?:-if)?))$/.test(nameString)) {
       this.#extractor.copy({
         start: attr.name.start,
-        end: attr.name.start + nameString.indexOf(":"),
+        end: attr.name.start + nameString.lastIndexOf(":"),
       });
     } else {
       this.#extractor.copy(attr.name);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

- `language-server`

## Description

- Remove modifiers from attributes in the extracted static html

## Motivation and Context

- Accessibility linter had false positives when an attribute that helped with accessibility included a modifier.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/b7eaf20f-6e6d-406a-9a98-7f76fd9a7b78)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
