### PR TITLE
fix: add const return to forAttrTag helpers

### DIFF
--- a/.changeset/big-games-peel.md
+++ b/.changeset/big-games-peel.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Allow type narrowing when attr tags are in for loops

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/__snapshots__/attr-tags-for-narrowing.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/__snapshots__/attr-tags-for-narrowing.expected/index.md
@@ -1,0 +1,12 @@
+## Hovers
+### Ln 3, Col 14
+```marko
+  1 | <list>
+  2 |   <for of=[1, 2, 3]>
+> 3 |     <@item size="small"/>
+    |              ^ (property) "size": "small"
+  4 |           // ^?
+  5 |   </for>
+  6 | </list>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/components/list.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/components/list.marko
@@ -1,0 +1,5 @@
+export interface Input {
+  item?: Marko.RepeatableAttrTag<{
+    size?: "small" | "large"
+  }>
+}

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/index.marko
@@ -1,5 +1,6 @@
 <list>
   <for of=[1, 2, 3]>
     <@item size="small"/>
+          // ^?
   </for>
 </list>

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/index.marko
@@ -1,0 +1,5 @@
+<list>
+  <for of=[1, 2, 3]>
+    <@item size="small"/>
+  </for>
+</list>

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -211,7 +211,7 @@ declare global {
 
       export function forAttrTag<
         Value extends Iterable<any> | readonly any[],
-        Return,
+        const Return,
       >(
         input: {
           of: Value;
@@ -231,7 +231,7 @@ declare global {
           : never;
       };
 
-      export function forAttrTag<Value extends object, Return>(
+      export function forAttrTag<Value extends object, const Return>(
         input: {
           in: Value;
         },
@@ -248,7 +248,7 @@ declare global {
         From extends void | number,
         To extends number,
         Step extends void | number,
-        Return,
+        const Return,
       >(
         input: {
           from?: From;
@@ -270,7 +270,7 @@ declare global {
           : never;
       };
 
-      export function forAttrTag<Return>(attrs: {
+      export function forAttrTag<const Return>(attrs: {
         input:
           | {
               of: any;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description

Type narrowing wasn't working for attr tags in a for loop, i.e.
```marko
<list>
  <for|item| of=items>
    <@item size="small"/>
             // ^^^^^^^ ERROR: `string` is not assignable to `"small"`
  </for>
</list>
```
```marko
// list.marko
export interface Input {
  item?: Marko.RepeatableAttrTag<{
    size?: "small" | "large"
  }>
}
```

## Motivation and Context

- Helps with ebay/ebayui-core#2282

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
