### PR TITLE
fix(language-server): move dependencies to package.json

### DIFF
--- a/.changeset/funny-steaks-run.md
+++ b/.changeset/funny-steaks-run.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-server": patch
+---
+
+Fix dependency issue

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,9 @@
       "workspaces": [
         "./packages/*"
       ],
-      "dependencies": {
-        "axe-core": "^4.10.2",
-        "jsdom": "^25.0.1"
-      },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.9",
-        "@types/jsdom": "^21.1.7",
         "@types/mocha": "^10.0.9",
         "@types/node": "^22.8.4",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -10688,7 +10683,9 @@
         "@marko/compiler": "^5.37.23",
         "@marko/language-tools": "^2.4.5",
         "@marko/translator-default": "^6.0.23",
+        "axe-core": "^4.10.2",
         "htmljs-parser": "^5.5.2",
+        "jsdom": "^25.0.1",
         "marko": "^5.35.32",
         "prettier": "^3.3.3",
         "prettier-plugin-marko": "^3.1.6",
@@ -10703,6 +10700,7 @@
         "marko-language-server": "bin.js"
       },
       "devDependencies": {
+        "@types/jsdom": "21.1.7",
         "@types/prettier": "^3.0.0",
         "tsx": "^4.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -19,12 +19,7 @@
     "mocha-snap": "^5.0.0",
     "prettier": "^3.3.3",
     "tsx": "^4.19.2",
-    "typescript": "^5.6.3",
-    "@types/jsdom": "^21.1.7"
-  },
-  "dependencies": {
-    "axe-core": "^4.10.2",
-    "jsdom": "^25.0.1"
+    "typescript": "^5.6.3"
   },
   "private": true,
   "scripts": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -21,10 +21,13 @@
     "vscode-css-languageservice": "^6.3.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12",
-    "vscode-uri": "^3.0.8"
+    "vscode-uri": "^3.0.8",
+    "axe-core": "^4.10.2",
+    "jsdom": "^25.0.1"
   },
   "devDependencies": {
     "@types/prettier": "^3.0.0",
+    "@types/jsdom": "21.1.7",
     "tsx": "^4.19.2"
   },
   "exports": {


### PR DESCRIPTION
- Fixes #297 


## Description

- Moves dependencies from the root level `package.json` to the one for `language-server`

## Motivation and Context

- Looks like I broke the language server back when I added axe-core support in #188 😅

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
