### PR TITLE
fix(axe-core): remove false positive for aria-prohibited-attr rule

### DIFF
--- a/packages/language-server/src/service/html/axe-rules/rule-exceptions.ts
+++ b/packages/language-server/src/service/html/axe-rules/rule-exceptions.ts
@@ -72,7 +72,7 @@ export const ruleExceptions: { [id in Whitelist]: Exceptions } = {
   [r.aria.ariaInputFieldName]: { unknownBody: true, attrSpread: true },
   [r.aria.ariaMeterName]: { unknownBody: true, attrSpread: true },
   [r.aria.ariaProgressbarName]: { unknownBody: true, attrSpread: true },
-  [r.aria.ariaProhibitedAttr]: {},
+  [r.aria.ariaProhibitedAttr]: { dynamicAttrs: ["role"] },
   [r.aria.ariaRequiredAttr]: { attrSpread: true },
   [r.aria.ariaRequiredChildren]: { unknownBody: true },
   [r.aria.ariaRoles]: { dynamicAttrs: ["role"] },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

- Accessibility linter

## Description

- Remove false positive for aria-prohibited-attr rule

## Screenshots:

<img width="920" alt="image" src="https://github.com/user-attachments/assets/92c3ad19-d004-4c2d-a38f-da55d767a24f">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
