### PR TITLE
fix(ts): client, server, satisfies, explicit type annotations

### DIFF
--- a/.changeset/honest-numbers-add.md
+++ b/.changeset/honest-numbers-add.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"marko-vscode": patch
+"@marko/type-check": patch
+---
+
+`client` and `server` statements, `satisfies` keyword, explicit type annotations on `let`

--- a/package-lock.json
+++ b/package-lock.json
@@ -4816,9 +4816,9 @@
       }
     },
     "node_modules/htmljs-parser": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.5.2.tgz",
-      "integrity": "sha512-5pNHk0dSIFLA0ucC2NJv4ikhOdAFKT2X3zo69uAd5fqt3AX4kaXD9F17k/98LKCn5u4Dd9PXeso2iJ0bFw0X+Q==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.5.3.tgz",
+      "integrity": "sha512-uX5BWkdIJV2qfxTVMcFJGPSqx9EYZGfZQv7THtNfA3cIr2zfwlzjojqO7jHDntO3cJUQauRSjBETBkiaCi3wtA==",
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
@@ -9262,7 +9262,7 @@
         "@marko/language-tools": "^2.4.6",
         "@marko/translator-default": "^6.1.0",
         "axe-core": "^4.10.2",
-        "htmljs-parser": "^5.5.2",
+        "htmljs-parser": "^5.5.3",
         "jsdom": "^25.0.1",
         "marko": "^5.36.0",
         "prettier": "^3.3.3",
@@ -9289,7 +9289,7 @@
       "dependencies": {
         "@babel/parser": "^7.26.2",
         "@luxass/strip-json-comments": "^1.3.2",
-        "htmljs-parser": "^5.5.2",
+        "htmljs-parser": "^5.5.3",
         "relative-import-path": "^1.0.0"
       },
       "devDependencies": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -12,7 +12,7 @@
     "@marko/babel-utils": "^6.6.0",
     "@marko/compiler": "^5.38.0",
     "@marko/translator-default": "^6.1.0",
-    "htmljs-parser": "^5.5.2",
+    "htmljs-parser": "^5.5.3",
     "marko": "^5.36.0",
     "prettier": "^3.3.3",
     "prettier-plugin-marko": "^3.1.7",

--- a/packages/language-tools/package.json
+++ b/packages/language-tools/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@babel/parser": "^7.26.2",
     "@luxass/strip-json-comments": "^1.3.2",
-    "htmljs-parser": "^5.5.2",
+    "htmljs-parser": "^5.5.3",
     "relative-import-path": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/language-tools/src/extractors/script/util/attach-scopes.ts
+++ b/packages/language-tools/src/extractors/script/util/attach-scopes.ts
@@ -159,12 +159,14 @@ export function crawlProgramScope(parsed: Parsed, scriptParser: ScriptParser) {
             parentScope.bindings ??= {};
 
             // TODO: should support member expression tag vars.
-            const parsedFn = scriptParser.expressionAt<
-              t.AssignmentExpression & { left: t.LVal }
-            >(child.var.value.start - 6, `${read(child.var.value)}=0`);
+            const parsedFn =
+              scriptParser.expressionAt<t.ArrowFunctionExpression>(
+                child.var.value.start - 1,
+                `(${read(child.var.value)})=>0`,
+              );
 
             if (parsedFn) {
-              const lVal = parsedFn.left;
+              const lVal = parsedFn.params[0];
               checkForMutations(parentScope, lVal);
 
               for (const id of getVarIdentifiers(

--- a/packages/language-tools/src/parser.ts
+++ b/packages/language-tools/src/parser.ts
@@ -504,6 +504,8 @@ class Builder {
 
           this.#comments = undefined;
           return TagType.statement;
+        case "server":
+        case "client":
         case "static":
           this.#program.static.push(
             (this.#staticNode = {

--- a/packages/vscode/syntaxes/marko.tmLanguage.json
+++ b/packages/vscode/syntaxes/marko.tmLanguage.json
@@ -105,7 +105,7 @@
           "name": "meta.marko-spread-attribute",
           "contentName": "source.ts",
           "begin": "(\\.\\.\\.)",
-          "end": "(?=[,;\\]]|/>|(?<=[^=])>|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^\\+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
+          "end": "(?=[,;\\]]|/>|(?<=[^=])>|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^\\+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|satisfies|as|extends)\\s+[^:=/,;>])))",
           "patterns": [{ "include": "#javascript-expression" }],
           "beginCaptures": { "1": { "name": "keyword.operator.spread.marko" } }
         },
@@ -123,7 +123,7 @@
       "name": "meta.embedded.ts",
       "contentName": "source.ts",
       "begin": "\\s*(:?=)\\s*",
-      "end": "(?=[,;\\]]|/>|(?<=[^=])>|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^\\+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
+      "end": "(?=[,;\\]]|/>|(?<=[^=])>|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^\\+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{(+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|satisfies|as|extends)\\s+[^:=/,;>])))",
       "patterns": [{ "include": "#javascript-expression" }],
       "beginCaptures": { "1": { "patterns": [{ "include": "source.ts" }] } }
     },
@@ -637,7 +637,7 @@
         {
           "comment": "We must match the some expressions ourselves since otherwise the js grammar can overstep.",
           "contentName": "source.ts",
-          "match": "(?:\\s*\\b(?:as|await|extends|in|instanceof|keyof|new|typeof|void))+\\s+(?![:=/,;>])[a-zA-Z0-9_$@#]*",
+          "match": "(?:\\s*\\b(?:as|await|extends|in|instanceof|satisfies|keyof|new|typeof|void))+\\s+(?![:=/,;>])[a-zA-Z0-9_$@#]*",
           "captures": { "0": { "patterns": [{ "include": "source.ts" }] } }
         },
         {
@@ -756,7 +756,7 @@
             {
               "comment": "Match type",
               "begin": "\\s*(:)(?!=)",
-              "end": "(?=[,;\\](]|/>|(?<=[^=])>|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^\\+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|as|extends)\\s+[^:=/,;>])))",
+              "end": "(?=[,;\\](]|/>|(?<=[^=])>|(?<!(?:^|[!~*%&^|?:]|[!~*%&^|?/<>+=-]=|=>|>{2,}|[^.]\\.|[^-]-|^\\s*\\+\\+|[^\\+]\\+{2}*\\+|[a-zA-Z0-9%).<\\]}]\\s*/|\\b(?<![.]\\s*)(?:await|async|class|function|keyof|new|typeof|void))\\s*)(?:\\n|[ \\t]+(?![\\n{+!~*%&^|?:]|[<>/=-]=|=>|>{2,}|\\.[^.]|-[^-]|/[^>]|(?:in|instanceof|satisfies|as|extends)\\s+[^:=/,;>])))",
               "patterns": [
                 { "include": "source.ts#type" },
                 { "include": "#javascript-expression" }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

<!-- Which package does this PR affect? -->

## Description

- Treat `client` and `server` statements like `static`
- Add support for the `satisfies` keyword
- Change the way explicit type annotations work for `let`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

<!--
Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so.
-->
