### PR TITLE
fix: stricter check before processing a script as javascript

### DIFF
--- a/.changeset/bright-windows-fly.md
+++ b/.changeset/bright-windows-fly.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Ensure script tags are only processed as javascript when they contain no other attributes or placeholders in the body content.

--- a/packages/language-tools/src/extractors/script/util/attach-scopes.ts
+++ b/packages/language-tools/src/extractors/script/util/attach-scopes.ts
@@ -8,6 +8,7 @@ import {
   Repeatable,
   Repeated,
 } from "../../../parser";
+import { isTextOnlyScript } from "./is-text-only-script";
 import type { ScriptParser } from "./script-parser";
 
 export interface Options {
@@ -224,7 +225,7 @@ export function crawlProgramScope(parsed: Parsed, scriptParser: ScriptParser) {
               }
             }
 
-            if (child.nameText === "script" && child.body) {
+            if (isTextOnlyScript(child)) {
               checkForMutations(
                 parentScope,
                 scriptParser.expressionAt(

--- a/packages/language-tools/src/extractors/script/util/is-text-only-script.ts
+++ b/packages/language-tools/src/extractors/script/util/is-text-only-script.ts
@@ -1,0 +1,20 @@
+import { type Node, NodeType, Repeated } from "../../../parser";
+
+export function isTextOnlyScript(tag: Node.ParentTag): tag is Node.Tag & {
+  nameText: "script";
+  args: undefined;
+  attrs: undefined;
+  body: Repeated<Node.Text>;
+} {
+  if (tag.nameText !== "script" || tag.args || tag.attrs || !tag.body) {
+    return false;
+  }
+
+  for (const child of tag.body) {
+    if (child.type !== NodeType.Text) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
Partially resolve #313 by adding more checks before processing a `<script>` as javascript/typescript code in the output.

@vwong FYI this change was made to align with the proposed future change of the tags api to make it such that the `<script>` tag is processed by Marko to act like the `<effect>` of the tags api preview. (https://github.com/marko-js/website/blob/next/src/routes/docs/core-tag.md#script.