### PR TITLE
fix(ts): nested attr tags in for-of loops

### DIFF
--- a/.changeset/new-dots-scream.md
+++ b/.changeset/new-dots-scream.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix TypeScript for nested attribute tags in for-of loops

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/__snapshots__/for-tag-attr-tags.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/__snapshots__/for-tag-attr-tags.expected/index.md
@@ -1,0 +1,43 @@
+## Hovers
+### Ln 6, Col 8
+```marko
+  4 |     { foo: "c", bar: "d" },
+  5 |   ]>
+> 6 |     <@row>
+    |        ^ (property) "@row": Marko.AttrTag<{
+    cell?: Marko.AttrTag<{
+        renderBody: Marko.Body;
+    }>;
+}> | undefined
+  7 |     // ^?
+  8 |       <@cell>${row.foo}</@cell>
+  9 |       // ^?     ^?
+```
+
+### Ln 8, Col 10
+```marko
+   6 |     <@row>
+   7 |     // ^?
+>  8 |       <@cell>${row.foo}</@cell>
+     |          ^ (property) "@cell": Marko.AttrTag<{
+    renderBody: Marko.Body;
+}> | undefined
+   9 |       // ^?     ^?
+  10 |       <@cell>${row.bar}</@cell>
+  11 |     </@row>
+```
+
+### Ln 8, Col 17
+```marko
+   6 |     <@row>
+   7 |     // ^?
+>  8 |       <@cell>${row.foo}</@cell>
+     |                 ^ (parameter) row: {
+    foo: string;
+    bar: string;
+}
+   9 |       // ^?     ^?
+  10 |       <@cell>${row.bar}</@cell>
+  11 |     </@row>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/components/my-table.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/components/my-table.marko
@@ -1,0 +1,5 @@
+export interface Input {
+  row?: Marko.AttrTag<{
+    cell?: Marko.AttrTag<{ renderBody: Marko.Body }>;
+  }>;
+}

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/index.marko
@@ -1,0 +1,13 @@
+<my-table>
+  <for|row| of=[
+    { foo: "a", bar: "b" },
+    { foo: "c", bar: "d" },
+  ]>
+    <@row>
+    // ^?
+      <@cell>${row.foo}</@cell>
+      // ^?     ^?
+      <@cell>${row.bar}</@cell>
+    </@row>
+  </for>
+</my-table>

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -331,11 +331,13 @@ declare global {
       ): <AttrTag>(
         attrTags: Relate<
           AttrTag,
-          Marko.Input<Tag> extends infer Input
-            ? [0] extends [1 & Input]
-              ? Marko.AttrTag<unknown>
-              : AttrTagValue<Marko.Input<Tag>, Path>
-            : Marko.AttrTag<unknown>
+          [0] extends [1 & Tag]
+            ? Marko.AttrTag<unknown>
+            : Marko.Input<Tag> extends infer Input
+              ? [0] extends [1 & Input]
+                ? Marko.AttrTag<unknown>
+                : AttrTagValue<Marko.Input<Tag>, Path>
+              : Marko.AttrTag<unknown>
         >[],
       ) => AttrTag;
 


### PR DESCRIPTION
No longer breaks:

```marko
<my-table>
  <for|row| of=[
    { foo: "a", bar: "b" },
    { foo: "c", bar: "d" },
  ]>
    <@row>
    // ^?
      <@cell>${row.foo}</@cell>
      // ^?     ^?
      <@cell>${row.bar}</@cell>
    </@row>
  </for>
</my-table>
```