### PR TITLE
fix: Setters to tag vars when there are tag params

### DIFF
--- a/.changeset/nasty-impalas-argue.md
+++ b/.changeset/nasty-impalas-argue.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix setters to tag vars in parent scopes in presence of tag params

--- a/packages/language-server/src/__tests__/fixtures/script/attr-class-id-shorthands/__snapshots__/attr-class-id-shorthands.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-class-id-shorthands/__snapshots__/attr-class-id-shorthands.expected/index.ts
@@ -15,14 +15,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/const/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: "hi",
-    }),
-  );
-  const value = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: "hi",
+  });
+  const value = __marko_internal_rendered_1.return.value;
   Marko._.renderNativeTag("div")()()({
     id: Marko._.interpolated`test`,
   });

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-dynamic-for/__snapshots__/attr-tags-dynamic-for.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-dynamic-for/__snapshots__/attr-tags-dynamic-for.expected/index.ts
@@ -32,24 +32,22 @@ export { type Component };
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: [
-        {
-          value: 1,
-        },
-        {
-          value: 2,
-        },
-        {
-          value: 3,
-        },
-      ] as const,
-    }),
-  );
-  const list = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: [
+      {
+        value: 1,
+      },
+      {
+        value: 2,
+      },
+      {
+        value: 3,
+      },
+    ] as const,
+  });
+  const list = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_3 = custom;
   Marko._.attrTagNames(__marko_internal_tag_3, (input) => {
     input["@a"];
@@ -131,45 +129,41 @@ export { type Component };
   Marko._.attrTagNames(__marko_internal_tag_6, (input) => {
     input["@a"];
   });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderDynamicTag(__marko_internal_tag_6)()()(
-      //      ^?
-      {
-        ...Marko._.forOfAttrTag(
-          {
-            /*for*/ of: list,
+  const __marko_internal_rendered_2 = Marko._.renderDynamicTag(
+    __marko_internal_tag_6,
+  )()()(
+    //      ^?
+    {
+      ...Marko._.forOfAttrTag(
+        {
+          /*for*/ of: list,
+        },
+        (item) => ({
+          ["a" /*@a*/]: {
+            ["renderBody" /*@a*/]: (() => {
+              const __marko_internal_tag_7 = Marko._.resolveTemplate(
+                import("../../../components/const/index.marko"),
+              );
+              const __marko_internal_rendered_3 = Marko._.renderTemplate(
+                __marko_internal_tag_7,
+              )()()({
+                value: item,
+              });
+              const { value: hoistedFromForOf } =
+                __marko_internal_rendered_3.return.value;
+              return () => {
+                return new (class MarkoReturn<Return = void> {
+                  [Marko._.scope] = { hoistedFromForOf };
+                  declare return: Return;
+                  constructor(_?: Return) {}
+                })();
+              };
+            })(),
+            [/*@a*/ Symbol.iterator]: Marko._.any,
           },
-          (item) => ({
-            ["a" /*@a*/]: {
-              ["renderBody" /*@a*/]: (() => {
-                const __marko_internal_tag_7 = Marko._.resolveTemplate(
-                  import("../../../components/const/index.marko"),
-                );
-                Marko._.assertRendered(
-                  Marko._.rendered,
-                  3,
-                  Marko._.renderTemplate(__marko_internal_tag_7)()()({
-                    value: item,
-                  }),
-                );
-                const { value: hoistedFromForOf } =
-                  Marko._.rendered.returns[3].value;
-                return () => {
-                  return new (class MarkoReturn<Return = void> {
-                    [Marko._.scope] = { hoistedFromForOf };
-                    declare return: Return;
-                    constructor(_?: Return) {}
-                  })();
-                };
-              })(),
-              [/*@a*/ Symbol.iterator]: Marko._.any,
-            },
-          }),
-        ),
-      },
-    ),
+        }),
+      ),
+    },
   );
   const __marko_internal_tag_8 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_8)()()({
@@ -181,14 +175,12 @@ export { type Component };
   const __marko_internal_tag_9 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    4,
-    Marko._.renderTemplate(__marko_internal_tag_9)()()({
-      value: { a: 1, b: 2 } as const,
-    }),
-  );
-  const record = Marko._.rendered.returns[4].value;
+  const __marko_internal_rendered_4 = Marko._.renderTemplate(
+    __marko_internal_tag_9,
+  )()()({
+    value: { a: 1, b: 2 } as const,
+  });
+  const record = __marko_internal_rendered_4.return.value;
   const __marko_internal_tag_10 = custom;
   Marko._.attrTagNames(__marko_internal_tag_10, (input) => {
     input["@a"];
@@ -216,44 +208,40 @@ export { type Component };
   Marko._.attrTagNames(__marko_internal_tag_11, (input) => {
     input["@a"];
   });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    5,
-    Marko._.renderDynamicTag(__marko_internal_tag_11)()()(
-      //      ^?     ^?
-      {
-        ...Marko._.forInAttrTag(
-          {
-            /*for*/ in: record,
+  const __marko_internal_rendered_5 = Marko._.renderDynamicTag(
+    __marko_internal_tag_11,
+  )()()(
+    //      ^?     ^?
+    {
+      ...Marko._.forInAttrTag(
+        {
+          /*for*/ in: record,
+        },
+        (key) => ({
+          ["a" /*@a*/]: {
+            ["renderBody" /*@a*/]: (() => {
+              const __marko_internal_tag_12 = Marko._.resolveTemplate(
+                import("../../../components/const/index.marko"),
+              );
+              const __marko_internal_rendered_6 = Marko._.renderTemplate(
+                __marko_internal_tag_12,
+              )()()({
+                value: key,
+              });
+              const hoistedFromForIn = __marko_internal_rendered_6.return.value;
+              return () => {
+                return new (class MarkoReturn<Return = void> {
+                  [Marko._.scope] = { hoistedFromForIn };
+                  declare return: Return;
+                  constructor(_?: Return) {}
+                })();
+              };
+            })(),
+            [/*@a*/ Symbol.iterator]: Marko._.any,
           },
-          (key) => ({
-            ["a" /*@a*/]: {
-              ["renderBody" /*@a*/]: (() => {
-                const __marko_internal_tag_12 = Marko._.resolveTemplate(
-                  import("../../../components/const/index.marko"),
-                );
-                Marko._.assertRendered(
-                  Marko._.rendered,
-                  6,
-                  Marko._.renderTemplate(__marko_internal_tag_12)()()({
-                    value: key,
-                  }),
-                );
-                const hoistedFromForIn = Marko._.rendered.returns[6].value;
-                return () => {
-                  return new (class MarkoReturn<Return = void> {
-                    [Marko._.scope] = { hoistedFromForIn };
-                    declare return: Return;
-                    constructor(_?: Return) {}
-                  })();
-                };
-              })(),
-              [/*@a*/ Symbol.iterator]: Marko._.any,
-            },
-          }),
-        ),
-      },
-    ),
+        }),
+      ),
+    },
   );
   const __marko_internal_tag_13 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_13)()()({
@@ -340,44 +328,40 @@ export { type Component };
   Marko._.attrTagNames(__marko_internal_tag_17, (input) => {
     input["@a"];
   });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    7,
-    Marko._.renderDynamicTag(__marko_internal_tag_17)()()(
-      //      ^?
-      {
-        ...Marko._.forToAttrTag(
-          {
-            /*for*/ to: 10,
+  const __marko_internal_rendered_7 = Marko._.renderDynamicTag(
+    __marko_internal_tag_17,
+  )()()(
+    //      ^?
+    {
+      ...Marko._.forToAttrTag(
+        {
+          /*for*/ to: 10,
+        },
+        (index) => ({
+          ["a" /*@a*/]: {
+            ["renderBody" /*@a*/]: (() => {
+              const __marko_internal_tag_18 = Marko._.resolveTemplate(
+                import("../../../components/const/index.marko"),
+              );
+              const __marko_internal_rendered_8 = Marko._.renderTemplate(
+                __marko_internal_tag_18,
+              )()()({
+                value: index,
+              });
+              const hoistedFromForTo = __marko_internal_rendered_8.return.value;
+              return () => {
+                return new (class MarkoReturn<Return = void> {
+                  [Marko._.scope] = { hoistedFromForTo };
+                  declare return: Return;
+                  constructor(_?: Return) {}
+                })();
+              };
+            })(),
+            [/*@a*/ Symbol.iterator]: Marko._.any,
           },
-          (index) => ({
-            ["a" /*@a*/]: {
-              ["renderBody" /*@a*/]: (() => {
-                const __marko_internal_tag_18 = Marko._.resolveTemplate(
-                  import("../../../components/const/index.marko"),
-                );
-                Marko._.assertRendered(
-                  Marko._.rendered,
-                  8,
-                  Marko._.renderTemplate(__marko_internal_tag_18)()()({
-                    value: index,
-                  }),
-                );
-                const hoistedFromForTo = Marko._.rendered.returns[8].value;
-                return () => {
-                  return new (class MarkoReturn<Return = void> {
-                    [Marko._.scope] = { hoistedFromForTo };
-                    declare return: Return;
-                    constructor(_?: Return) {}
-                  })();
-                };
-              })(),
-              [/*@a*/ Symbol.iterator]: Marko._.any,
-            },
-          }),
-        ),
-      },
-    ),
+        }),
+      ),
+    },
   );
   const __marko_internal_tag_19 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_19)()()({
@@ -387,7 +371,13 @@ export { type Component };
     },
   });
   const { hoistedFromForOf, hoistedFromForIn, hoistedFromForTo } =
-    Marko._.readScopes(Marko._.rendered);
+    Marko._.readScopes({
+      __marko_internal_rendered_1,
+      __marko_internal_rendered_2,
+      __marko_internal_rendered_4,
+      __marko_internal_rendered_5,
+      __marko_internal_rendered_7,
+    });
   Marko._.noop({ hoistedFromForOf, hoistedFromForIn, hoistedFromForTo });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-dynamic-if/__snapshots__/attr-tags-dynamic-if.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-dynamic-if/__snapshots__/attr-tags-dynamic-if.expected/index.ts
@@ -188,82 +188,77 @@ export { type Component };
     input["@b"];
     input["@b"];
   });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderDynamicTag(__marko_internal_tag_9)()()({
-      x: 1,
-      ...Marko._.mergeAttrTags(
-        {
-          // hi
-          ["a" /*@a*/]: {
-            b: 1,
-            ["renderBody" /*@a*/]: (() => {
-              const __marko_internal_tag_10 = Marko._.resolveTemplate(
-                import("../../../components/const/index.marko"),
-              );
-              Marko._.assertRendered(
-                Marko._.rendered,
-                2,
-                Marko._.renderTemplate(__marko_internal_tag_10)()()({
-                  value: 1 as const,
-                }),
-              );
-              const hoistedFromStaticMember = Marko._.rendered.returns[2].value;
-              return () => {
-                return new (class MarkoReturn<Return = void> {
-                  [Marko._.scope] = { hoistedFromStaticMember };
-                  declare return: Return;
-                  constructor(_?: Return) {}
-                })();
-              };
-            })(),
-            [/*@a*/ Symbol.iterator]: Marko._.any,
-          },
-          ["b" /*@b*/]: {
-            [/*@b*/ Symbol.iterator]: Marko._.any,
-            /*@b*/
-          },
+  const __marko_internal_rendered_1 = Marko._.renderDynamicTag(
+    __marko_internal_tag_9,
+  )()()({
+    x: 1,
+    ...Marko._.mergeAttrTags(
+      {
+        // hi
+        ["a" /*@a*/]: {
+          b: 1,
+          ["renderBody" /*@a*/]: (() => {
+            const __marko_internal_tag_10 = Marko._.resolveTemplate(
+              import("../../../components/const/index.marko"),
+            );
+            const __marko_internal_rendered_2 = Marko._.renderTemplate(
+              __marko_internal_tag_10,
+            )()()({
+              value: 1 as const,
+            });
+            const hoistedFromStaticMember =
+              __marko_internal_rendered_2.return.value;
+            return () => {
+              return new (class MarkoReturn<Return = void> {
+                [Marko._.scope] = { hoistedFromStaticMember };
+                declare return: Return;
+                constructor(_?: Return) {}
+              })();
+            };
+          })(),
+          [/*@a*/ Symbol.iterator]: Marko._.any,
         },
-        x
-          ? {
-              ["b" /*@b*/]: {
-                ["renderBody" /*@b*/]: (() => {
-                  const __marko_internal_tag_11 = Marko._.resolveTemplate(
-                    import("../../../components/const/index.marko"),
-                  );
-                  Marko._.assertRendered(
-                    Marko._.rendered,
-                    3,
-                    Marko._.renderTemplate(__marko_internal_tag_11)()()({
-                      value: 2 as const,
-                    }),
-                  );
-                  const hoistedFromDynamicMember =
-                    Marko._.rendered.returns[3].value;
-                  return () => {
-                    return new (class MarkoReturn<Return = void> {
-                      [Marko._.scope] = { hoistedFromDynamicMember };
-                      declare return: Return;
-                      constructor(_?: Return) {}
-                    })();
-                  };
-                })(),
-                [/*@b*/ Symbol.iterator]: Marko._.any,
-              },
-            }
-          : {},
-        y
-          ? {
-              ["a" /*@a*/]: {
-                [/*@a*/ Symbol.iterator]: Marko._.any,
-                /*@a*/
-              },
-            }
-          : {},
-      ),
-    }),
-  );
+        ["b" /*@b*/]: {
+          [/*@b*/ Symbol.iterator]: Marko._.any,
+          /*@b*/
+        },
+      },
+      x
+        ? {
+            ["b" /*@b*/]: {
+              ["renderBody" /*@b*/]: (() => {
+                const __marko_internal_tag_11 = Marko._.resolveTemplate(
+                  import("../../../components/const/index.marko"),
+                );
+                const __marko_internal_rendered_3 = Marko._.renderTemplate(
+                  __marko_internal_tag_11,
+                )()()({
+                  value: 2 as const,
+                });
+                const hoistedFromDynamicMember =
+                  __marko_internal_rendered_3.return.value;
+                return () => {
+                  return new (class MarkoReturn<Return = void> {
+                    [Marko._.scope] = { hoistedFromDynamicMember };
+                    declare return: Return;
+                    constructor(_?: Return) {}
+                  })();
+                };
+              })(),
+              [/*@b*/ Symbol.iterator]: Marko._.any,
+            },
+          }
+        : {},
+      y
+        ? {
+            ["a" /*@a*/]: {
+              [/*@a*/ Symbol.iterator]: Marko._.any,
+              /*@a*/
+            },
+          }
+        : {},
+    ),
+  });
   const __marko_internal_tag_12 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_12)()()({
     value() {
@@ -274,7 +269,7 @@ export { type Component };
     },
   });
   const { hoistedFromStaticMember, hoistedFromDynamicMember } =
-    Marko._.readScopes(Marko._.rendered);
+    Marko._.readScopes({ __marko_internal_rendered_1 });
   Marko._.noop({ hoistedFromStaticMember, hoistedFromDynamicMember });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-static-dynamic-renderbody/__snapshots__/attr-tags-static-dynamic-renderbody.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-static-dynamic-renderbody/__snapshots__/attr-tags-static-dynamic-renderbody.expected/index.ts
@@ -15,14 +15,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: false,
-    }),
-  );
-  const someCondition = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: false,
+  });
+  const someCondition = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = custom;
   Marko._.attrTagNames(__marko_internal_tag_2, (input) => {
     input["@header"];

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-static/__snapshots__/attr-tags-static.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-static/__snapshots__/attr-tags-static.expected/index.ts
@@ -18,49 +18,46 @@ export { type Component };
     input["@b"];
     input["@a"];
   });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderDynamicTag(__marko_internal_tag_1)()()({
-      ["b" /*@b*/]: Marko._.attrTagFor(
-        __marko_internal_tag_1,
-        "b",
-      )([
-        {
-          [/*@b*/ Symbol.iterator]: Marko._.any,
-          /*@b*/
-        },
-        {
-          c: 2,
-          [/*@b*/ Symbol.iterator]: Marko._.any,
-        },
-      ]),
-      ["a" /*@a*/]: {
-        b: 1,
-        ["renderBody" /*@a*/]: (() => {
-          const __marko_internal_tag_2 = Marko._.resolveTemplate(
-            import("../../../components/const/index.marko"),
-          );
-          Marko._.assertRendered(
-            Marko._.rendered,
-            2,
-            Marko._.renderTemplate(__marko_internal_tag_2)()()({
-              value: 1 as const,
-            }),
-          );
-          const hoistedFromStaticMember = Marko._.rendered.returns[2].value;
-          return () => {
-            return new (class MarkoReturn<Return = void> {
-              [Marko._.scope] = { hoistedFromStaticMember };
-              declare return: Return;
-              constructor(_?: Return) {}
-            })();
-          };
-        })(),
-        [/*@a*/ Symbol.iterator]: Marko._.any,
+  const __marko_internal_rendered_1 = Marko._.renderDynamicTag(
+    __marko_internal_tag_1,
+  )()()({
+    ["b" /*@b*/]: Marko._.attrTagFor(
+      __marko_internal_tag_1,
+      "b",
+    )([
+      {
+        [/*@b*/ Symbol.iterator]: Marko._.any,
+        /*@b*/
       },
-    }),
-  );
+      {
+        c: 2,
+        [/*@b*/ Symbol.iterator]: Marko._.any,
+      },
+    ]),
+    ["a" /*@a*/]: {
+      b: 1,
+      ["renderBody" /*@a*/]: (() => {
+        const __marko_internal_tag_2 = Marko._.resolveTemplate(
+          import("../../../components/const/index.marko"),
+        );
+        const __marko_internal_rendered_2 = Marko._.renderTemplate(
+          __marko_internal_tag_2,
+        )()()({
+          value: 1 as const,
+        });
+        const hoistedFromStaticMember =
+          __marko_internal_rendered_2.return.value;
+        return () => {
+          return new (class MarkoReturn<Return = void> {
+            [Marko._.scope] = { hoistedFromStaticMember };
+            declare return: Return;
+            constructor(_?: Return) {}
+          })();
+        };
+      })(),
+      [/*@a*/ Symbol.iterator]: Marko._.any,
+    },
+  });
   const __marko_internal_tag_3 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_3)()()({
     value() {
@@ -68,7 +65,9 @@ export { type Component };
       //^?
     },
   });
-  const { hoistedFromStaticMember } = Marko._.readScopes(Marko._.rendered);
+  const { hoistedFromStaticMember } = Marko._.readScopes({
+    __marko_internal_rendered_1,
+  });
   Marko._.noop({ hoistedFromStaticMember });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/basic/__snapshots__/basic.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/basic/__snapshots__/basic.expected/index.ts
@@ -14,40 +14,34 @@ export { type Component };
     (Marko._.error, Marko._.any as MarkoRun.Context),
   );
   Marko._.noop({ component, state, out, input, $global, $signal });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderNativeTag("div")()()({
-      ["renderBody" /*div*/]: (() => {
-        const __marko_internal_tag_1 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          2,
-          Marko._.renderTemplate(__marko_internal_tag_1)()()({
-            value: 1,
-          }),
-        );
-        const x = Marko._.rendered.returns[2].value;
-        new Thing();
-        //      ^?
-        x;
-        //  ^?
-        input.name;
-        return () => {
-          return new (class MarkoReturn<Return = void> {
-            [Marko._.scope] = { x };
-            declare return: Return;
-            constructor(_?: Return) {}
-          })();
-        };
-      })(),
-    }),
-  );
+  const __marko_internal_rendered_1 = Marko._.renderNativeTag("div")()()({
+    ["renderBody" /*div*/]: (() => {
+      const __marko_internal_tag_1 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_1,
+      )()()({
+        value: 1,
+      });
+      const x = __marko_internal_rendered_2.return.value;
+      new Thing();
+      //      ^?
+      x;
+      //  ^?
+      input.name;
+      return () => {
+        return new (class MarkoReturn<Return = void> {
+          [Marko._.scope] = { x };
+          declare return: Return;
+          constructor(_?: Return) {}
+        })();
+      };
+    })(),
+  });
   //        ^?
   x;
-  const { x } = Marko._.readScopes(Marko._.rendered);
+  const { x } = Marko._.readScopes({ __marko_internal_rendered_1 });
   Marko._.noop({ x });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-const-dynamic-member/__snapshots__/bound-attr-const-dynamic-member.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-const-dynamic-member/__snapshots__/bound-attr-const-dynamic-member.expected/index.ts
@@ -15,26 +15,22 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: { b: 1 },
-    }),
-  );
-  const a = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: { b: 1 },
+  });
+  const a = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: a["b"],
-      valueChange: a[`${"b"}Change`],
-    }),
-  );
-  const b = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: a["b"],
+    valueChange: a[`${"b"}Change`],
+  });
+  const b = __marko_internal_rendered_2.return.value;
   return;
 })();
 export default new (class Template extends Marko._.Template<{

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-const-ident/__snapshots__/bound-attr-const-ident.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-const-ident/__snapshots__/bound-attr-const-ident.expected/index.ts
@@ -15,31 +15,27 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/const/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: 1,
-    }),
-  );
-  const a = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: 1,
+  });
+  const a = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: a,
-      valueChange(_a) {
-        __marko_internal_return.mutate.a = _a;
-      },
-    }),
-  );
-  const b = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: a,
+    valueChange(_a) {
+      __marko_internal_return.mutate.a = _a;
+    },
+  });
+  const b = __marko_internal_rendered_2.return.value;
   const __marko_internal_return = {
     mutate: Marko._.mutable([
-      ["a", "value", Marko._.rendered.returns[1]],
+      ["a", "value", __marko_internal_rendered_1.return],
     ] as const),
   };
   Marko._.noop({

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-const-literal-member/__snapshots__/bound-attr-const-literal-member.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-const-literal-member/__snapshots__/bound-attr-const-literal-member.expected/index.ts
@@ -15,26 +15,22 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: { b: 1 },
-    }),
-  );
-  const a = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: { b: 1 },
+  });
+  const a = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: a.b,
-      valueChange: a.bChange,
-    }),
-  );
-  const b = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: a.b,
+    valueChange: a.bChange,
+  });
+  const b = __marko_internal_rendered_2.return.value;
   return;
 })();
 export default new (class Template extends Marko._.Template<{

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-missing-ident/__snapshots__/bound-attr-missing-ident.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-missing-ident/__snapshots__/bound-attr-missing-ident.expected/index.ts
@@ -15,17 +15,15 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: a,
-      valueChange(_a) {
-        a = _a;
-      },
-    }),
-  );
-  const b = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: a,
+    valueChange(_a) {
+      a = _a;
+    },
+  });
+  const b = __marko_internal_rendered_1.return.value;
   return;
 })();
 export default new (class Template extends Marko._.Template<{

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-mut-dynamic-member/__snapshots__/bound-attr-mut-dynamic-member.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-mut-dynamic-member/__snapshots__/bound-attr-mut-dynamic-member.expected/index.ts
@@ -15,26 +15,22 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: { b: 1, bChange(value: number) {} },
-    }),
-  );
-  const a = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: { b: 1, bChange(value: number) {} },
+  });
+  const a = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: a["b"],
-      valueChange: a[`${"b"}Change`],
-    }),
-  );
-  const b = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: a["b"],
+    valueChange: a[`${"b"}Change`],
+  });
+  const b = __marko_internal_rendered_2.return.value;
   return;
 })();
 export default new (class Template extends Marko._.Template<{

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-mut-ident/__snapshots__/bound-attr-mut-ident.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-mut-ident/__snapshots__/bound-attr-mut-ident.expected/index.ts
@@ -15,28 +15,24 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: 1,
-    }),
-  );
-  const a = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: 1,
+  });
+  const a = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: a,
-      valueChange(_a) {
-        __marko_internal_return.mutate.a = _a;
-      },
-    }),
-  );
-  const b = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: a,
+    valueChange(_a) {
+      __marko_internal_return.mutate.a = _a;
+    },
+  });
+  const b = __marko_internal_rendered_2.return.value;
   Marko._.renderNativeTag("div")()()(
     //   ^?   ^?
     {
@@ -48,8 +44,8 @@ export { type Component };
   );
   const __marko_internal_return = {
     mutate: Marko._.mutable([
-      ["a", "value", Marko._.rendered.returns[1]],
-      ["b", "value", Marko._.rendered.returns[2]],
+      ["a", "value", __marko_internal_rendered_1.return],
+      ["b", "value", __marko_internal_rendered_2.return],
     ] as const),
   };
   Marko._.noop({

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-mut-literal-member/__snapshots__/bound-attr-mut-literal-member.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-mut-literal-member/__snapshots__/bound-attr-mut-literal-member.expected/index.ts
@@ -15,26 +15,22 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: { b: 1, bChange(value: number) {} },
-    }),
-  );
-  const a = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: { b: 1, bChange(value: number) {} },
+  });
+  const a = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: a.b,
-      valueChange: a.bChange,
-    }),
-  );
-  const b = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: a.b,
+    valueChange: a.bChange,
+  });
+  const b = __marko_internal_rendered_2.return.value;
   return;
 })();
 export default new (class Template extends Marko._.Template<{

--- a/packages/language-server/src/__tests__/fixtures/script/dynamic-tag/__snapshots__/dynamic-tag.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/dynamic-tag/__snapshots__/dynamic-tag.expected/index.ts
@@ -15,14 +15,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: 1,
-    }),
-  );
-  const size = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: 1,
+  });
+  const size = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.interpolated`h${size}`;
   Marko._.renderDynamicTag(__marko_internal_tag_2)()()({
     ["renderBody" /*h${size}*/]: (() => {

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag/__snapshots__/for-tag.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag/__snapshots__/for-tag.expected/index.ts
@@ -15,24 +15,22 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: [
-        {
-          value: 1,
-        },
-        {
-          value: 2,
-        },
-        {
-          value: 3,
-        },
-      ] as const,
-    }),
-  );
-  const list = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: [
+      {
+        value: 1,
+      },
+      {
+        value: 2,
+      },
+      {
+        value: 3,
+      },
+    ] as const,
+  });
+  const list = __marko_internal_rendered_1.return.value;
   Marko._.forOfTag(
     {
       /*for*/ of: list,
@@ -64,35 +62,30 @@ export { type Component };
         return Marko._.voidReturn;
       },
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.forOfTag(
-      {
-        /*for*/ of: list,
-      },
-      (
-        //               ^?    ^?
-        item,
-      ) => {
-        const __marko_internal_tag_2 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          3,
-          Marko._.renderTemplate(__marko_internal_tag_2)()()({
-            value: item,
-          }),
-        );
-        const { value: hoistedFromForOf } = Marko._.rendered.returns[3].value;
-        return new (class MarkoReturn<Return = void> {
-          [Marko._.scope] = { hoistedFromForOf };
-          declare return: Return;
-          constructor(_?: Return) {}
-        })();
-      },
-    ),
+  const __marko_internal_rendered_2 = Marko._.forOfTag(
+    {
+      /*for*/ of: list,
+    },
+    (
+      //               ^?    ^?
+      item,
+    ) => {
+      const __marko_internal_tag_2 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_3 = Marko._.renderTemplate(
+        __marko_internal_tag_2,
+      )()()({
+        value: item,
+      });
+      const { value: hoistedFromForOf } =
+        __marko_internal_rendered_3.return.value;
+      return new (class MarkoReturn<Return = void> {
+        [Marko._.scope] = { hoistedFromForOf };
+        declare return: Return;
+        constructor(_?: Return) {}
+      })();
+    },
   );
   Marko._.forOfTag(
     {
@@ -112,14 +105,12 @@ export { type Component };
   const __marko_internal_tag_4 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    4,
-    Marko._.renderTemplate(__marko_internal_tag_4)()()({
-      value: { a: 1, b: 2 } as const,
-    }),
-  );
-  const record = Marko._.rendered.returns[4].value;
+  const __marko_internal_rendered_4 = Marko._.renderTemplate(
+    __marko_internal_tag_4,
+  )()()({
+    value: { a: 1, b: 2 } as const,
+  });
+  const record = __marko_internal_rendered_4.return.value;
   Marko._.forInTag(
     {
       /*for*/ in: record,
@@ -142,35 +133,29 @@ export { type Component };
         return Marko._.voidReturn;
       },
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    5,
-    Marko._.forInTag(
-      {
-        /*for*/ in: record,
-      },
-      (
-        //                 ^?     ^?
-        key,
-      ) => {
-        const __marko_internal_tag_5 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          6,
-          Marko._.renderTemplate(__marko_internal_tag_5)()()({
-            value: key,
-          }),
-        );
-        const hoistedFromForIn = Marko._.rendered.returns[6].value;
-        return new (class MarkoReturn<Return = void> {
-          [Marko._.scope] = { hoistedFromForIn };
-          declare return: Return;
-          constructor(_?: Return) {}
-        })();
-      },
-    ),
+  const __marko_internal_rendered_5 = Marko._.forInTag(
+    {
+      /*for*/ in: record,
+    },
+    (
+      //                 ^?     ^?
+      key,
+    ) => {
+      const __marko_internal_tag_5 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_6 = Marko._.renderTemplate(
+        __marko_internal_tag_5,
+      )()()({
+        value: key,
+      });
+      const hoistedFromForIn = __marko_internal_rendered_6.return.value;
+      return new (class MarkoReturn<Return = void> {
+        [Marko._.scope] = { hoistedFromForIn };
+        declare return: Return;
+        constructor(_?: Return) {}
+      })();
+    },
   );
   const __marko_internal_tag_6 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_6)()()({
@@ -226,35 +211,29 @@ export { type Component };
       return Marko._.voidReturn;
     },
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    7,
-    Marko._.forToTag(
-      {
-        /*for*/ to: 10,
-      },
-      (
-        //  ^?
-        index,
-      ) => {
-        const __marko_internal_tag_7 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          8,
-          Marko._.renderTemplate(__marko_internal_tag_7)()()({
-            value: index,
-          }),
-        );
-        const hoistedFromForTo = Marko._.rendered.returns[8].value;
-        return new (class MarkoReturn<Return = void> {
-          [Marko._.scope] = { hoistedFromForTo };
-          declare return: Return;
-          constructor(_?: Return) {}
-        })();
-      },
-    ),
+  const __marko_internal_rendered_7 = Marko._.forToTag(
+    {
+      /*for*/ to: 10,
+    },
+    (
+      //  ^?
+      index,
+    ) => {
+      const __marko_internal_tag_7 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_8 = Marko._.renderTemplate(
+        __marko_internal_tag_7,
+      )()()({
+        value: index,
+      });
+      const hoistedFromForTo = __marko_internal_rendered_8.return.value;
+      return new (class MarkoReturn<Return = void> {
+        [Marko._.scope] = { hoistedFromForTo };
+        declare return: Return;
+        constructor(_?: Return) {}
+      })();
+    },
   );
   const __marko_internal_tag_8 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_8)()()({
@@ -272,7 +251,13 @@ export { type Component };
     },
   );
   const { hoistedFromForOf, hoistedFromForIn, hoistedFromForTo } =
-    Marko._.readScopes(Marko._.rendered);
+    Marko._.readScopes({
+      __marko_internal_rendered_1,
+      __marko_internal_rendered_2,
+      __marko_internal_rendered_4,
+      __marko_internal_rendered_5,
+      __marko_internal_rendered_7,
+    });
   Marko._.noop({ hoistedFromForOf, hoistedFromForIn, hoistedFromForTo });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/if-tag/__snapshots__/if-tag.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/if-tag/__snapshots__/if-tag.expected/index.ts
@@ -15,25 +15,21 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: true,
-    }),
-  );
-  const show = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: true,
+  });
+  const show = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      value: false,
-    }),
-  );
-  const showAlt = Marko._.rendered.returns[2].value;
+  const __marko_internal_rendered_2 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    value: false,
+  });
+  const showAlt = __marko_internal_rendered_2.return.value;
   if (undefined) {
   }
   if (show) {
@@ -52,209 +48,165 @@ export { type Component };
   if (show) {
   } else {
   }
-  Marko._.assertRendered(
-    Marko._.rendered,
-    3,
-    (() => {
-      if (show) {
-        const __marko_internal_tag_3 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          4,
-          Marko._.renderTemplate(__marko_internal_tag_3)()()({
-            value: 0 as const,
-          }),
-        );
-        const a = Marko._.rendered.returns[4].value;
-        return {
-          scope: { a },
-        };
-      } else {
-        return undefined;
-      }
-    })(),
-  );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    5,
-    (() => {
-      if (show) {
-        const __marko_internal_tag_4 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          6,
-          Marko._.renderTemplate(__marko_internal_tag_4)()()({
-            value: 1 as const,
-          }),
-        );
-        const b = Marko._.rendered.returns[6].value;
-        return {
-          scope: { b },
-        };
-      } else if (showAlt) {
-        const __marko_internal_tag_5 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          7,
-          Marko._.renderTemplate(__marko_internal_tag_5)()()({
-            value: 2 as const,
-          }),
-        );
-        const c = Marko._.rendered.returns[7].value;
-        return {
-          scope: { c },
-        };
-      } else {
-        const __marko_internal_tag_6 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          8,
-          Marko._.renderTemplate(__marko_internal_tag_6)()()({
-            value: 3 as const,
-          }),
-        );
-        const d = Marko._.rendered.returns[8].value;
-        return {
-          scope: { d },
-        };
-      }
-    })(),
-  );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    9,
-    (() => {
-      if (show) {
-      } else {
-        const __marko_internal_tag_7 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          10,
-          Marko._.renderTemplate(__marko_internal_tag_7)()()({
-            value: 4 as const,
-          }),
-        );
-        const e = Marko._.rendered.returns[10].value;
-        return {
-          scope: { e },
-        };
-      }
-    })(),
-  );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    11,
-    (() => {
-      if (show) {
-      } else if (showAlt) {
-      } else {
-        const __marko_internal_tag_8 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          12,
-          Marko._.renderTemplate(__marko_internal_tag_8)()()({
-            value: 4 as const,
-          }),
-        );
-        const f = Marko._.rendered.returns[12].value;
-        return {
-          scope: { f },
-        };
-      }
-    })(),
-  );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    13,
-    (() => {
-      if (show) {
-        const __marko_internal_tag_9 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          14,
-          Marko._.renderTemplate(__marko_internal_tag_9)()()({
-            value: 5 as const,
-          }),
-        );
-        const g = Marko._.rendered.returns[14].value;
-        return {
-          scope: { g },
-        };
-      } else {
-        const __marko_internal_tag_10 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          15,
-          Marko._.renderTemplate(__marko_internal_tag_10)()()({
-            value: 6 as const,
-          }),
-        );
-        const g = Marko._.rendered.returns[15].value;
-        return {
-          scope: { g },
-        };
-      }
-    })(),
-  );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    16,
-    (() => {
+  const __marko_internal_rendered_3 = (() => {
+    if (show) {
+      const __marko_internal_tag_3 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_4 = Marko._.renderTemplate(
+        __marko_internal_tag_3,
+      )()()({
+        value: 0 as const,
+      });
+      const a = __marko_internal_rendered_4.return.value;
+      return {
+        scope: { a },
+      };
+    } else {
+      return undefined;
+    }
+  })();
+  const __marko_internal_rendered_5 = (() => {
+    if (show) {
+      const __marko_internal_tag_4 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_6 = Marko._.renderTemplate(
+        __marko_internal_tag_4,
+      )()()({
+        value: 1 as const,
+      });
+      const b = __marko_internal_rendered_6.return.value;
+      return {
+        scope: { b },
+      };
+    } else if (showAlt) {
+      const __marko_internal_tag_5 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_7 = Marko._.renderTemplate(
+        __marko_internal_tag_5,
+      )()()({
+        value: 2 as const,
+      });
+      const c = __marko_internal_rendered_7.return.value;
+      return {
+        scope: { c },
+      };
+    } else {
+      const __marko_internal_tag_6 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_8 = Marko._.renderTemplate(
+        __marko_internal_tag_6,
+      )()()({
+        value: 3 as const,
+      });
+      const d = __marko_internal_rendered_8.return.value;
+      return {
+        scope: { d },
+      };
+    }
+  })();
+  const __marko_internal_rendered_9 = (() => {
+    if (show) {
+    } else {
+      const __marko_internal_tag_7 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_10 = Marko._.renderTemplate(
+        __marko_internal_tag_7,
+      )()()({
+        value: 4 as const,
+      });
+      const e = __marko_internal_rendered_10.return.value;
+      return {
+        scope: { e },
+      };
+    }
+  })();
+  const __marko_internal_rendered_11 = (() => {
+    if (show) {
+    } else if (showAlt) {
+    } else {
+      const __marko_internal_tag_8 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_12 = Marko._.renderTemplate(
+        __marko_internal_tag_8,
+      )()()({
+        value: 4 as const,
+      });
+      const f = __marko_internal_rendered_12.return.value;
+      return {
+        scope: { f },
+      };
+    }
+  })();
+  const __marko_internal_rendered_13 = (() => {
+    if (show) {
+      const __marko_internal_tag_9 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_14 = Marko._.renderTemplate(
+        __marko_internal_tag_9,
+      )()()({
+        value: 5 as const,
+      });
+      const g = __marko_internal_rendered_14.return.value;
+      return {
+        scope: { g },
+      };
+    } else {
+      const __marko_internal_tag_10 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_15 = Marko._.renderTemplate(
+        __marko_internal_tag_10,
+      )()()({
+        value: 6 as const,
+      });
+      const g = __marko_internal_rendered_15.return.value;
+      return {
+        scope: { g },
+      };
+    }
+  })();
+  const __marko_internal_rendered_16 = (() => {
+    if (show) {
+    } else if (showAlt) {
       if (show) {
       } else if (showAlt) {
-        if (show) {
-        } else if (showAlt) {
-          const __marko_internal_tag_11 = Marko._.resolveTemplate(
-            import("../../../components/const/index.marko"),
-          );
-          Marko._.assertRendered(
-            Marko._.rendered,
-            17,
-            Marko._.renderTemplate(__marko_internal_tag_11)()()({
-              value: 7 as const,
-            }),
-          );
-          const h = Marko._.rendered.returns[17].value;
-          return {
-            scope: { h },
-          };
-        } else {
-          const __marko_internal_tag_12 = Marko._.resolveTemplate(
-            import("../../../components/const/index.marko"),
-          );
-          Marko._.assertRendered(
-            Marko._.rendered,
-            18,
-            Marko._.renderTemplate(__marko_internal_tag_12)()()({
-              value: 8 as const,
-            }),
-          );
-          const i = Marko._.rendered.returns[18].value;
-          return {
-            scope: { i },
-          };
-        }
+        const __marko_internal_tag_11 = Marko._.resolveTemplate(
+          import("../../../components/const/index.marko"),
+        );
+        const __marko_internal_rendered_17 = Marko._.renderTemplate(
+          __marko_internal_tag_11,
+        )()()({
+          value: 7 as const,
+        });
+        const h = __marko_internal_rendered_17.return.value;
+        return {
+          scope: { h },
+        };
       } else {
-        return undefined;
+        const __marko_internal_tag_12 = Marko._.resolveTemplate(
+          import("../../../components/const/index.marko"),
+        );
+        const __marko_internal_rendered_18 = Marko._.renderTemplate(
+          __marko_internal_tag_12,
+        )()()({
+          value: 8 as const,
+        });
+        const i = __marko_internal_rendered_18.return.value;
+        return {
+          scope: { i },
+        };
       }
-    })(),
-  );
+    } else {
+      return undefined;
+    }
+  })();
   if (show) {
   } else if (undefined) {
   }
@@ -289,7 +241,16 @@ export { type Component };
       //^?
     },
   });
-  const { a, b, c, d, e, f, g, h, i } = Marko._.readScopes(Marko._.rendered);
+  const { a, b, c, d, e, f, g, h, i } = Marko._.readScopes({
+    __marko_internal_rendered_1,
+    __marko_internal_rendered_2,
+    __marko_internal_rendered_3,
+    __marko_internal_rendered_5,
+    __marko_internal_rendered_9,
+    __marko_internal_rendered_11,
+    __marko_internal_rendered_13,
+    __marko_internal_rendered_16,
+  });
   Marko._.noop({ a, b, c, d, e, f, g, h, i });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/prefer-local-identifier-tag-name/__snapshots__/prefer-local-identifier-tag-name.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/prefer-local-identifier-tag-name/__snapshots__/prefer-local-identifier-tag-name.expected/index.ts
@@ -17,14 +17,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/const/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: CustomTagA,
-    }),
-  );
-  const TestTagA = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: CustomTagA,
+  });
+  const TestTagA = __marko_internal_rendered_1.return.value;
   const __marko_internal_tag_2 = Marko._.fallbackTemplate(
     TestTagA,
     import("./components/TestTagA.marko"),
@@ -44,14 +42,12 @@ export { type Component };
       const __marko_internal_tag_4 = Marko._.resolveTemplate(
         import("../../../components/const/index.marko"),
       );
-      Marko._.assertRendered(
-        Marko._.rendered,
-        2,
-        Marko._.renderTemplate(__marko_internal_tag_4)()()({
-          value: CustomTagB,
-        }),
-      );
-      const TestTagA = Marko._.rendered.returns[2].value;
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_4,
+      )()()({
+        value: CustomTagB,
+      });
+      const TestTagA = __marko_internal_rendered_2.return.value;
       const __marko_internal_tag_5 = Marko._.fallbackTemplate(
         TestTagA,
         import("./components/TestTagA.marko"),

--- a/packages/language-server/src/__tests__/fixtures/script/recursive-input-scope-hoist/__snapshots__/recursive-input-scope-hoist.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/recursive-input-scope-hoist/__snapshots__/recursive-input-scope-hoist.expected/index.ts
@@ -22,58 +22,33 @@ export { type Component };
       input["@comment"];
     });
   });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      ["comment" /*@comment*/]: Marko._.attrTagFor(
-        __marko_internal_tag_1,
-        "comment",
-      )([
-        {
-          id: Marko._.interpolated`a`,
-          ["comment" /*@comment*/]: {
-            id: Marko._.interpolated`b`,
-            ["renderBody" /*@comment*/]: (() => {
-              const __marko_internal_tag_2 = Marko._.resolveTemplate(
-                import("../../../components/let/index.marko"),
-              );
-              Marko._.assertRendered(
-                Marko._.rendered,
-                2,
-                Marko._.renderTemplate(__marko_internal_tag_2)()()(
-                  //    ^?
-                  {
-                    value: "b" as const,
-                  },
-                ),
-              );
-              const b = Marko._.rendered.returns[2].value;
-              return () => {
-                return new (class MarkoReturn<Return = void> {
-                  [Marko._.scope] = { b };
-                  declare return: Return;
-                  constructor(_?: Return) {}
-                })();
-              };
-            })(),
-            [/*@comment*/ Symbol.iterator]: Marko._.any,
-          },
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    ["comment" /*@comment*/]: Marko._.attrTagFor(
+      __marko_internal_tag_1,
+      "comment",
+    )([
+      {
+        id: Marko._.interpolated`a`,
+        ["comment" /*@comment*/]: {
+          id: Marko._.interpolated`b`,
           ["renderBody" /*@comment*/]: (() => {
-            const __marko_internal_tag_3 = Marko._.resolveTemplate(
+            const __marko_internal_tag_2 = Marko._.resolveTemplate(
               import("../../../components/let/index.marko"),
             );
-            Marko._.assertRendered(
-              Marko._.rendered,
-              3,
-              Marko._.renderTemplate(__marko_internal_tag_3)()()({
-                value: "a" as const,
-              }),
+            const __marko_internal_rendered_2 = Marko._.renderTemplate(
+              __marko_internal_tag_2,
+            )()()(
+              //    ^?
+              {
+                value: "b" as const,
+              },
             );
-            const a = Marko._.rendered.returns[3].value;
+            const b = __marko_internal_rendered_2.return.value;
             return () => {
               return new (class MarkoReturn<Return = void> {
-                [Marko._.scope] = { a };
+                [Marko._.scope] = { b };
                 declare return: Return;
                 constructor(_?: Return) {}
               })();
@@ -81,33 +56,50 @@ export { type Component };
           })(),
           [/*@comment*/ Symbol.iterator]: Marko._.any,
         },
-        {
-          id: Marko._.interpolated`c`,
-          ["renderBody" /*@comment*/]: (() => {
-            const __marko_internal_tag_4 = Marko._.resolveTemplate(
-              import("../../../components/let/index.marko"),
-            );
-            Marko._.assertRendered(
-              Marko._.rendered,
-              4,
-              Marko._.renderTemplate(__marko_internal_tag_4)()()({
-                value: "c" as const,
-              }),
-            );
-            const c = Marko._.rendered.returns[4].value;
-            return () => {
-              return new (class MarkoReturn<Return = void> {
-                [Marko._.scope] = { c };
-                declare return: Return;
-                constructor(_?: Return) {}
-              })();
-            };
-          })(),
-          [/*@comment*/ Symbol.iterator]: Marko._.any,
-        },
-      ]),
-    }),
-  );
+        ["renderBody" /*@comment*/]: (() => {
+          const __marko_internal_tag_3 = Marko._.resolveTemplate(
+            import("../../../components/let/index.marko"),
+          );
+          const __marko_internal_rendered_3 = Marko._.renderTemplate(
+            __marko_internal_tag_3,
+          )()()({
+            value: "a" as const,
+          });
+          const a = __marko_internal_rendered_3.return.value;
+          return () => {
+            return new (class MarkoReturn<Return = void> {
+              [Marko._.scope] = { a };
+              declare return: Return;
+              constructor(_?: Return) {}
+            })();
+          };
+        })(),
+        [/*@comment*/ Symbol.iterator]: Marko._.any,
+      },
+      {
+        id: Marko._.interpolated`c`,
+        ["renderBody" /*@comment*/]: (() => {
+          const __marko_internal_tag_4 = Marko._.resolveTemplate(
+            import("../../../components/let/index.marko"),
+          );
+          const __marko_internal_rendered_4 = Marko._.renderTemplate(
+            __marko_internal_tag_4,
+          )()()({
+            value: "c" as const,
+          });
+          const c = __marko_internal_rendered_4.return.value;
+          return () => {
+            return new (class MarkoReturn<Return = void> {
+              [Marko._.scope] = { c };
+              declare return: Return;
+              constructor(_?: Return) {}
+            })();
+          };
+        })(),
+        [/*@comment*/ Symbol.iterator]: Marko._.any,
+      },
+    ]),
+  });
   const __marko_internal_tag_5 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_5)()()({
     value() {
@@ -119,7 +111,7 @@ export { type Component };
       //^?
     },
   });
-  const { b, a, c } = Marko._.readScopes(Marko._.rendered);
+  const { b, a, c } = Marko._.readScopes({ __marko_internal_rendered_1 });
   Marko._.noop({ b, a, c });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/return-tag-nested/__snapshots__/return-tag-nested.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/return-tag-nested/__snapshots__/return-tag-nested.expected/index.ts
@@ -77,42 +77,38 @@ export { type Component };
   const __marko_internal_tag_5 = Marko._.resolveTemplate(
     import("./components/test-tag.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_5)()()({
-      ["renderBody" /*test-tag*/]: (() => {
-        const __marko_internal_tag_6 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          2,
-          Marko._.renderTemplate(__marko_internal_tag_6)()()({
-            value: 1 as const,
-          }),
-        );
-        const hoisted = Marko._.rendered.returns[2].value;
-        const __marko_internal_return = {
-          return: Marko._.returnTag({
-            value: "b" as const,
-          }),
-        };
-        return () => {
-          return new (class MarkoReturn<Return = void> {
-            [Marko._.scope] = { hoisted };
-            declare return: Return;
-            constructor(_?: Return) {}
-          })(__marko_internal_return.return);
-        };
-      })(),
-    }),
-  );
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_5,
+  )()()({
+    ["renderBody" /*test-tag*/]: (() => {
+      const __marko_internal_tag_6 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_6,
+      )()()({
+        value: 1 as const,
+      });
+      const hoisted = __marko_internal_rendered_2.return.value;
+      const __marko_internal_return = {
+        return: Marko._.returnTag({
+          value: "b" as const,
+        }),
+      };
+      return () => {
+        return new (class MarkoReturn<Return = void> {
+          [Marko._.scope] = { hoisted };
+          declare return: Return;
+          constructor(_?: Return) {}
+        })(__marko_internal_return.return);
+      };
+    })(),
+  });
   () => {
     hoisted;
     //^?
   };
-  const { hoisted } = Marko._.readScopes(Marko._.rendered);
+  const { hoisted } = Marko._.readScopes({ __marko_internal_rendered_1 });
   Marko._.noop({ hoisted });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/script/__snapshots__/script.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/script/__snapshots__/script.expected/index.ts
@@ -14,82 +14,72 @@ export { type Component };
     (Marko._.error, Marko._.any as MarkoRun.Context),
   );
   Marko._.noop({ component, state, out, input, $global, $signal });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderNativeTag("div")()()({
-      ["renderBody" /*div*/]: (() => {
-        const __marko_internal_tag_1 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          2,
-          Marko._.renderTemplate(__marko_internal_tag_1)()()({
-            value: 1,
-          }),
-        );
-        const x = Marko._.rendered.returns[2].value;
-        const __marko_internal_tag_2 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          3,
-          Marko._.renderTemplate(__marko_internal_tag_2)()()({
-            value: "hi",
-          }),
-        );
-        const y = Marko._.rendered.returns[3].value;
-        const __marko_internal_tag_3 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          4,
-          Marko._.renderTemplate(__marko_internal_tag_3)()()({
-            value: Promise.resolve("world"),
-          }),
-        );
-        const promise = Marko._.rendered.returns[4].value;
-        Marko._.renderNativeTag("script")()()({
-          async value() {
-            console.log(x);
-            //              ^?
-            console.log(y);
-            //              ^?
-            console.log(input.name);
-            //                    ^?
+  const __marko_internal_rendered_1 = Marko._.renderNativeTag("div")()()({
+    ["renderBody" /*div*/]: (() => {
+      const __marko_internal_tag_1 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_1,
+      )()()({
+        value: 1,
+      });
+      const x = __marko_internal_rendered_2.return.value;
+      const __marko_internal_tag_2 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_3 = Marko._.renderTemplate(
+        __marko_internal_tag_2,
+      )()()({
+        value: "hi",
+      });
+      const y = __marko_internal_rendered_3.return.value;
+      const __marko_internal_tag_3 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_4 = Marko._.renderTemplate(
+        __marko_internal_tag_3,
+      )()()({
+        value: Promise.resolve("world"),
+      });
+      const promise = __marko_internal_rendered_4.return.value;
+      Marko._.renderNativeTag("script")()()({
+        async value() {
+          console.log(x);
+          //              ^?
+          console.log(y);
+          //              ^?
+          console.log(input.name);
+          //                    ^?
 
-            const resolved = await promise;
-            console.log(resolved);
-            //          ^?
-            __marko_internal_return.mutate.x = 2;
-            __marko_internal_return.mutate.y = "bye";
-          },
-          /*script*/
-        });
-        const __marko_internal_return = {
-          mutate: Marko._.mutable([
-            ["x", "value", Marko._.rendered.returns[2]],
-            ["y", "value", Marko._.rendered.returns[3]],
-          ] as const),
-        };
-        Marko._.noop({
-          x,
-          y,
-        });
-        return () => {
-          return new (class MarkoReturn<Return = void> {
-            [Marko._.scope] = { x, y, promise };
-            declare return: Return;
-            constructor(_?: Return) {}
-          })();
-        };
-      })(),
-    }),
-  );
-  const { x, y, promise } = Marko._.readScopes(Marko._.rendered);
+          const resolved = await promise;
+          console.log(resolved);
+          //          ^?
+          __marko_internal_return.mutate.x = 2;
+          __marko_internal_return.mutate.y = "bye";
+        },
+        /*script*/
+      });
+      const __marko_internal_return = {
+        mutate: Marko._.mutable([
+          ["x", "value", __marko_internal_rendered_2.return],
+          ["y", "value", __marko_internal_rendered_3.return],
+        ] as const),
+      };
+      Marko._.noop({
+        x,
+        y,
+      });
+      return () => {
+        return new (class MarkoReturn<Return = void> {
+          [Marko._.scope] = { x, y, promise };
+          declare return: Return;
+          constructor(_?: Return) {}
+        })();
+      };
+    })(),
+  });
+  const { x, y, promise } = Marko._.readScopes({ __marko_internal_rendered_1 });
   Marko._.noop({ x, y, promise });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/simple-hoist/__snapshots__/simple-hoist.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/simple-hoist/__snapshots__/simple-hoist.expected/index.ts
@@ -12,58 +12,50 @@ export { type Component };
     (Marko._.error, Marko._.any as MarkoRun.Context),
   );
   Marko._.noop({ component, state, out, input, $global, $signal });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderNativeTag("div")()()({
-      ["renderBody" /*div*/]: (() => {
-        const __marko_internal_tag_1 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          2,
-          Marko._.renderTemplate(__marko_internal_tag_1)()()({
-            value: 1,
-          }),
-        );
-        const x = Marko._.rendered.returns[2].value;
-        x;
-        Marko._.assertRendered(
-          Marko._.rendered,
-          3,
-          Marko._.renderNativeTag("button")()()({
-            onClick() {
-              __marko_internal_return.mutate.x = 2;
-              __marko_internal_return.mutate.x++;
-              ++__marko_internal_return.mutate.x;
-            },
-            ["renderBody" /*button*/]: (() => {
-              return () => {
-                return Marko._.voidReturn;
-              };
-            })(),
-          }),
-        );
-        const el = Marko._.rendered.returns[3].value;
-        const __marko_internal_return = {
-          mutate: Marko._.mutable([
-            ["x", "value", Marko._.rendered.returns[2]],
-          ] as const),
-        };
-        Marko._.noop({
-          x,
-        });
-        return () => {
-          return new (class MarkoReturn<Return = void> {
-            [Marko._.scope] = { x, el };
-            declare return: Return;
-            constructor(_?: Return) {}
-          })();
-        };
-      })(),
-    }),
-  );
+  const __marko_internal_rendered_1 = Marko._.renderNativeTag("div")()()({
+    ["renderBody" /*div*/]: (() => {
+      const __marko_internal_tag_1 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_1,
+      )()()({
+        value: 1,
+      });
+      const x = __marko_internal_rendered_2.return.value;
+      x;
+      const __marko_internal_rendered_3 = Marko._.renderNativeTag("button")()()(
+        {
+          onClick() {
+            __marko_internal_return.mutate.x = 2;
+            __marko_internal_return.mutate.x++;
+            ++__marko_internal_return.mutate.x;
+          },
+          ["renderBody" /*button*/]: (() => {
+            return () => {
+              return Marko._.voidReturn;
+            };
+          })(),
+        },
+      );
+      const el = __marko_internal_rendered_3.return.value;
+      const __marko_internal_return = {
+        mutate: Marko._.mutable([
+          ["x", "value", __marko_internal_rendered_2.return],
+        ] as const),
+      };
+      Marko._.noop({
+        x,
+      });
+      return () => {
+        return new (class MarkoReturn<Return = void> {
+          [Marko._.scope] = { x, el };
+          declare return: Return;
+          constructor(_?: Return) {}
+        })();
+      };
+    })(),
+  });
   const __marko_internal_tag_2 = Marko._.interpolated`effect`;
   Marko._.renderDynamicTag(__marko_internal_tag_2)()()({
     value() {
@@ -72,7 +64,7 @@ export { type Component };
     },
   });
   x;
-  const { x, el } = Marko._.readScopes(Marko._.rendered);
+  const { x, el } = Marko._.readScopes({ __marko_internal_rendered_1 });
   Marko._.noop({ x, el });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/components/test-tag.ts
@@ -1,7 +1,9 @@
-export interface Input {}
+export interface Input {
+  renderBody: Marko.Body<[string]>;
+}
 abstract class Component extends Marko.Component<Input> {}
 export { type Component };
-function __marko_internal_template(this: void) {
+(function (this: void) {
   const input = Marko._.any as Input;
   const component = Marko._.any as Component;
   const state = Marko._.state(component);
@@ -12,33 +14,12 @@ function __marko_internal_template(this: void) {
     (Marko._.error, Marko._.any as MarkoRun.Context),
   );
   Marko._.noop({ component, state, out, input, $global, $signal });
-  const __marko_internal_tag_1 = Marko._.resolveTemplate(
-    import("../../../components/let/index.marko"),
-  );
-  const __marko_internal_rendered_1 = Marko._.renderTemplate(
-    __marko_internal_tag_1,
-  )()()({
-    value: 1,
+  const __marko_internal_tag_1 = input.renderBody;
+  Marko._.renderDynamicTag(__marko_internal_tag_1)()()({
+    value: ["foo"],
   });
-  const value = __marko_internal_rendered_1.return.value;
-  Marko._.renderNativeTag("button")()()({
-    onClick() {
-      __marko_internal_return.mutate.value++;
-    },
-  });
-  const __marko_internal_return = {
-    return: Marko._.returnTag({
-      value: value,
-    }),
-    mutate: Marko._.mutable([
-      ["value", __marko_internal_rendered_1.return],
-    ] as const),
-  };
-  Marko._.noop({
-    value,
-  });
-  return __marko_internal_return.return;
-}
+  return;
+})();
 export default new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
@@ -66,8 +47,5 @@ export default new (class Template extends Marko._.Template<{
     input: Marko.Directives &
       Input &
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
-  ) => Marko._.ReturnWithScope<
-    __marko_internal_input,
-    typeof __marko_internal_template extends () => infer Return ? Return : never
-  >;
+  ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.html
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.html
@@ -1,0 +1,6 @@
+<div>
+  <button data-marko-node-id="2" onClick>
+                  
+    placeholder
+  </button>
+</div>

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.md
@@ -1,0 +1,32 @@
+## Hovers
+### Ln 1, Col 7
+```marko
+> 1 | <let/string="bar"/>
+    |       ^ const string: string
+  2 |   //  ^?
+  3 | <test-tag|val|>
+  4 |   <button onClick() { string = val }>
+```
+
+### Ln 4, Col 24
+```marko
+  2 |   //  ^?
+  3 | <test-tag|val|>
+> 4 |   <button onClick() { string = val }>
+    |                        ^ (property) string: string
+  5 |                   //   ^?      ^?
+  6 |     ${val}
+  7 |   </button>
+```
+
+### Ln 4, Col 32
+```marko
+  2 |   //  ^?
+  3 | <test-tag|val|>
+> 4 |   <button onClick() { string = val }>
+    |                                ^ (parameter) val: string
+  5 |                   //   ^?      ^?
+  6 |     ${val}
+  7 |   </button>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.ts
@@ -1,7 +1,7 @@
 export interface Input {}
 abstract class Component extends Marko.Component<Input> {}
 export { type Component };
-function __marko_internal_template(this: void) {
+(function (this: void) {
   const input = Marko._.any as Input;
   const component = Marko._.any as Component;
   const state = Marko._.state(component);
@@ -18,27 +18,40 @@ function __marko_internal_template(this: void) {
   const __marko_internal_rendered_1 = Marko._.renderTemplate(
     __marko_internal_tag_1,
   )()()({
-    value: 1,
+    value: "bar",
   });
-  const value = __marko_internal_rendered_1.return.value;
-  Marko._.renderNativeTag("button")()()({
-    onClick() {
-      __marko_internal_return.mutate.value++;
+  const string = __marko_internal_rendered_1.return.value;
+  const __marko_internal_tag_2 = Marko._.resolveTemplate(
+    import("./components/test-tag.marko"),
+  );
+  Marko._.renderTemplate(__marko_internal_tag_2)()()({
+    //  ^?
+    ["renderBody" /*test-tag*/]: (val) => {
+      Marko._.renderNativeTag("button")()()({
+        onClick() {
+          __marko_internal_return.mutate.string = val;
+        },
+        ["renderBody" /*button*/]: (() => {
+          //   ^?      ^?
+          val;
+          return () => {
+            return Marko._.voidReturn;
+          };
+        })(),
+      });
+      const __marko_internal_return = {
+        mutate: Marko._.mutable([
+          ["string", "value", __marko_internal_rendered_1.return],
+        ] as const),
+      };
+      Marko._.noop({
+        string,
+      });
+      return Marko._.voidReturn;
     },
   });
-  const __marko_internal_return = {
-    return: Marko._.returnTag({
-      value: value,
-    }),
-    mutate: Marko._.mutable([
-      ["value", __marko_internal_rendered_1.return],
-    ] as const),
-  };
-  Marko._.noop({
-    value,
-  });
-  return __marko_internal_return.return;
-}
+  return;
+})();
 export default new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
@@ -66,8 +79,5 @@ export default new (class Template extends Marko._.Template<{
     input: Marko.Directives &
       Input &
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
-  ) => Marko._.ReturnWithScope<
-    __marko_internal_input,
-    typeof __marko_internal_template extends () => infer Return ? Return : never
-  >;
+  ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/components/test-tag.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/components/test-tag.marko
@@ -1,0 +1,5 @@
+export interface Input {
+  renderBody: Marko.Body<[string]>
+}
+
+<${input.renderBody}=["foo"] />

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/index.marko
@@ -1,0 +1,8 @@
+<let/string="bar"/>
+  //  ^?
+<test-tag|val|>
+  <button onClick() { string = val }>
+                  //   ^?      ^?
+    ${val}
+  </button>
+</test-tag>

--- a/packages/language-server/src/__tests__/fixtures/script/tag-params-basic/__snapshots__/tag-params-basic.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-params-basic/__snapshots__/tag-params-basic.expected/index.ts
@@ -26,39 +26,37 @@ export { type Component };
   const __marko_internal_tag_2 = Marko._.resolveTemplate(
     import("./components/test-tag.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_2)()()({
-      //  ^?   ^?
-      ["renderBody" /*test-tag*/]: (a) => {
-        const __marko_internal_tag_3 = Marko._.resolveTemplate(
-          import("../../../components/const/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          2,
-          Marko._.renderTemplate(__marko_internal_tag_3)()()(
-            //        ^?
-            {
-              value: a,
-            },
-          ),
-        );
-        const hoistedFromTestTag = Marko._.rendered.returns[2].value;
-        return new (class MarkoReturn<Return = void> {
-          [Marko._.scope] = { hoistedFromTestTag };
-          declare return: Return;
-          constructor(_?: Return) {}
-        })();
-      },
-    }),
-  );
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_2,
+  )()()({
+    //  ^?   ^?
+    ["renderBody" /*test-tag*/]: (a) => {
+      const __marko_internal_tag_3 = Marko._.resolveTemplate(
+        import("../../../components/const/index.marko"),
+      );
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_3,
+      )()()(
+        //        ^?
+        {
+          value: a,
+        },
+      );
+      const hoistedFromTestTag = __marko_internal_rendered_2.return.value;
+      return new (class MarkoReturn<Return = void> {
+        [Marko._.scope] = { hoistedFromTestTag };
+        declare return: Return;
+        constructor(_?: Return) {}
+      })();
+    },
+  });
   () => {
     hoistedFromTestTag;
     //^?
   };
-  const { hoistedFromTestTag } = Marko._.readScopes(Marko._.rendered);
+  const { hoistedFromTestTag } = Marko._.readScopes({
+    __marko_internal_rendered_1,
+  });
   Marko._.noop({ hoistedFromTestTag });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/tag-type-params/__snapshots__/tag-type-params.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-type-params/__snapshots__/tag-type-params.expected/index.ts
@@ -15,28 +15,26 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("./components/test-tag.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      data: 1 as const,
-      ["renderBody" /*test-tag*/]: <A,>(data: A) => {
-        const __marko_internal_return = {
-          return: Marko._.returnTag(
-            //                         ^?
-            {
-              value: { result: data },
-            },
-          ),
-        };
-        return new (class MarkoReturn<Return = void> {
-          declare return: Return;
-          constructor(_?: Return) {}
-        })(__marko_internal_return.return);
-      },
-    }),
-  );
-  const result = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    data: 1 as const,
+    ["renderBody" /*test-tag*/]: <A,>(data: A) => {
+      const __marko_internal_return = {
+        return: Marko._.returnTag(
+          //                         ^?
+          {
+            value: { result: data },
+          },
+        ),
+      };
+      return new (class MarkoReturn<Return = void> {
+        declare return: Return;
+        constructor(_?: Return) {}
+      })(__marko_internal_return.return);
+    },
+  });
+  const result = __marko_internal_rendered_1.return.value;
   //                  ^?
   result;
   return;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-var-hoisting/__snapshots__/tag-var-hoisting.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-var-hoisting/__snapshots__/tag-var-hoisting.expected/index.ts
@@ -12,62 +12,54 @@ export { type Component };
     (Marko._.error, Marko._.any as MarkoRun.Context),
   );
   Marko._.noop({ component, state, out, input, $global, $signal });
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderNativeTag("div")()()({
-      ["renderBody" /*div*/]: (() => {
-        const __marko_internal_tag_1 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          2,
-          Marko._.renderTemplate(__marko_internal_tag_1)()()({
-            value: {
-              a: 1,
-              b: "hello!",
-              c: undefined,
-              nested: {
-                d: 2,
-                dChange(v: number) {},
-              },
-              "some-alias": 3,
-              computed: 4,
-              other: true,
-            } as const,
-          }),
-        );
-        const {
-          a,
-          b,
-          c = "default" as const,
-          nested: { d },
-          "some-alias": e,
-          ["computed"]: f,
-          ...g
-        } = Marko._.rendered.returns[2].value;
-        const __marko_internal_tag_2 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          3,
-          Marko._.renderTemplate(__marko_internal_tag_2)()()({
-            value: [1, 2, 3, 4, 5] as const,
-          }),
-        );
-        const [h, i, , ...j] = Marko._.rendered.returns[3].value;
-        return () => {
-          return new (class MarkoReturn<Return = void> {
-            [Marko._.scope] = { a, b, c, d, e, f, g, h, i, j };
-            declare return: Return;
-            constructor(_?: Return) {}
-          })();
-        };
-      })(),
-    }),
-  );
+  const __marko_internal_rendered_1 = Marko._.renderNativeTag("div")()()({
+    ["renderBody" /*div*/]: (() => {
+      const __marko_internal_tag_1 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_2 = Marko._.renderTemplate(
+        __marko_internal_tag_1,
+      )()()({
+        value: {
+          a: 1,
+          b: "hello!",
+          c: undefined,
+          nested: {
+            d: 2,
+            dChange(v: number) {},
+          },
+          "some-alias": 3,
+          computed: 4,
+          other: true,
+        } as const,
+      });
+      const {
+        a,
+        b,
+        c = "default" as const,
+        nested: { d },
+        "some-alias": e,
+        ["computed"]: f,
+        ...g
+      } = __marko_internal_rendered_2.return.value;
+      const __marko_internal_tag_2 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_3 = Marko._.renderTemplate(
+        __marko_internal_tag_2,
+      )()()({
+        value: [1, 2, 3, 4, 5] as const,
+      });
+      const [h, i, , ...j] = __marko_internal_rendered_3.return.value;
+      return () => {
+        return new (class MarkoReturn<Return = void> {
+          [Marko._.scope] = { a, b, c, d, e, f, g, h, i, j };
+          declare return: Return;
+          constructor(_?: Return) {}
+        })();
+      };
+    })(),
+  });
   () => {
     a;
     //^?
@@ -90,7 +82,9 @@ export { type Component };
     j;
     //^?
   };
-  const { a, b, c, d, e, f, g, h, i, j } = Marko._.readScopes(Marko._.rendered);
+  const { a, b, c, d, e, f, g, h, i, j } = Marko._.readScopes({
+    __marko_internal_rendered_1,
+  });
   Marko._.noop({ a, b, c, d, e, f, g, h, i, j });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/tag-var-mutation-shadowing/__snapshots__/tag-var-mutation-shadowing.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-var-mutation-shadowing/__snapshots__/tag-var-mutation-shadowing.expected/index.ts
@@ -15,14 +15,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/const/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: "",
-    }),
-  );
-  const x = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: "",
+  });
+  const x = __marko_internal_rendered_1.return.value;
   Marko._.renderNativeTag("div")()()({
     onClick() {
       __marko_internal_return.mutate.x = "Hello!";
@@ -182,7 +180,7 @@ export { type Component };
   });
   const __marko_internal_return = {
     mutate: Marko._.mutable([
-      ["x", "value", Marko._.rendered.returns[1]],
+      ["x", "value", __marko_internal_rendered_1.return],
     ] as const),
   };
   Marko._.noop({

--- a/packages/language-server/src/__tests__/fixtures/script/tag-var-mutations-nested/__snapshots__/tag-var-mutations-nested.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-var-mutations-nested/__snapshots__/tag-var-mutations-nested.expected/index.ts
@@ -15,14 +15,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: 1,
-    }),
-  );
-  const x = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: 1,
+  });
+  const x = __marko_internal_rendered_1.return.value;
   Marko._.renderNativeTag("button")()()({
     onClick() {
       __marko_internal_return.mutate.x++;
@@ -35,64 +33,63 @@ export { type Component };
     })(),
   });
   const __marko_internal_tag_2 = Marko._.interpolated`foo`;
-  Marko._.assertRendered(
-    Marko._.rendered,
-    2,
-    Marko._.renderDynamicTag(__marko_internal_tag_2)()()({
-      ["renderBody" /*foo*/]: (() => {
-        const __marko_internal_tag_3 = Marko._.resolveTemplate(
-          import("../../../components/let/index.marko"),
-        );
-        Marko._.assertRendered(
-          Marko._.rendered,
-          3,
-          Marko._.renderTemplate(__marko_internal_tag_3)()()({
-            value: "hello",
-          }),
-        );
-        const y = Marko._.rendered.returns[3].value;
-        Marko._.renderNativeTag("button")()()({
-          onClick() {
-            __marko_internal_return.mutate.x++;
-            //  ^?
-            __marko_internal_return.mutate.y = "goodbye";
-            //  ^?
-          },
-          ["renderBody" /*button*/]: (() => {
-            return () => {
-              return Marko._.voidReturn;
-            };
-          })(),
-        });
-        const __marko_internal_return = {
-          mutate: Marko._.mutable([
-            ["x", "value", Marko._.rendered.returns[1]],
-            ["y", "value", Marko._.rendered.returns[3]],
-          ] as const),
-        };
-        Marko._.noop({
-          x,
-          y,
-        });
-        return () => {
-          return new (class MarkoReturn<Return = void> {
-            [Marko._.scope] = { y };
-            declare return: Return;
-            constructor(_?: Return) {}
-          })();
-        };
-      })(),
-    }),
-  );
+  const __marko_internal_rendered_2 = Marko._.renderDynamicTag(
+    __marko_internal_tag_2,
+  )()()({
+    ["renderBody" /*foo*/]: (() => {
+      const __marko_internal_tag_3 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_3 = Marko._.renderTemplate(
+        __marko_internal_tag_3,
+      )()()({
+        value: "hello",
+      });
+      const y = __marko_internal_rendered_3.return.value;
+      Marko._.renderNativeTag("button")()()({
+        onClick() {
+          __marko_internal_return.mutate.x++;
+          //  ^?
+          __marko_internal_return.mutate.y = "goodbye";
+          //  ^?
+        },
+        ["renderBody" /*button*/]: (() => {
+          return () => {
+            return Marko._.voidReturn;
+          };
+        })(),
+      });
+      const __marko_internal_return = {
+        mutate: Marko._.mutable([
+          ["x", "value", __marko_internal_rendered_1.return],
+          ["y", "value", __marko_internal_rendered_3.return],
+        ] as const),
+      };
+      Marko._.noop({
+        x,
+        y,
+      });
+      return () => {
+        return new (class MarkoReturn<Return = void> {
+          [Marko._.scope] = { y };
+          declare return: Return;
+          constructor(_?: Return) {}
+        })();
+      };
+    })(),
+  });
   const __marko_internal_return = {
     mutate: Marko._.mutable([
-      ["x", "value", Marko._.rendered.returns[1]],
+      ["x", "value", __marko_internal_rendered_1.return],
     ] as const),
   };
   Marko._.noop({
     x,
   });
-  const { y } = Marko._.readScopes(Marko._.rendered);
+  const { y } = Marko._.readScopes({
+    __marko_internal_rendered_1,
+    __marko_internal_rendered_2,
+  });
   Marko._.noop({ y });
   return;
 })();

--- a/packages/language-server/src/__tests__/fixtures/script/tag-var-mutations/__snapshots__/tag-var-mutations.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-var-mutations/__snapshots__/tag-var-mutations.expected/index.ts
@@ -15,14 +15,12 @@ export { type Component };
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/let/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: 1,
-    }),
-  );
-  const x = Marko._.rendered.returns[1].value;
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: 1,
+  });
+  const x = __marko_internal_rendered_1.return.value;
   Marko._.renderNativeTag("div")()()({
     "data-function"() {
       __marko_internal_return.mutate.x++;
@@ -89,7 +87,7 @@ export { type Component };
   });
   const __marko_internal_return = {
     mutate: Marko._.mutable([
-      ["x", "value", Marko._.rendered.returns[1]],
+      ["x", "value", __marko_internal_rendered_1.return],
     ] as const),
   };
   Marko._.noop({

--- a/packages/language-server/src/__tests__/fixtures/script/tag-var-syntax-error/__snapshots__/tag-var-syntax-error.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-var-syntax-error/__snapshots__/tag-var-syntax-error.expected/index.ts
@@ -15,14 +15,14 @@ export { type Component }
 const __marko_internal_tag_1 = (
 Marko._.resolveTemplate(import("../../../components/let/index.marko"))
 );
-Marko._.assertRendered(Marko._.rendered,1,Marko._.renderTemplate(__marko_internal_tag_1)()()(// Should be resistant to syntax errors.
+const __marko_internal_rendered_1 = Marko._.renderTemplate(__marko_internal_tag_1)()()(// Should be resistant to syntax errors.
 {
  "value": (
 1
 ),
 
-}));
-const { %x } = Marko._.rendered.returns[1].value;
+});
+const { %x } = __marko_internal_rendered_1.return.value;
 return;
 })();
 export default new (

--- a/packages/language-server/src/__tests__/fixtures/script/tags-api-basic/__snapshots__/tags-api-basic.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tags-api-basic/__snapshots__/tags-api-basic.expected/index.ts
@@ -29,15 +29,13 @@ function __marko_internal_template(this: void) {
   const __marko_internal_tag_1 = Marko._.resolveTemplate(
     import("../../../components/const/index.marko"),
   );
-  Marko._.assertRendered(
-    Marko._.rendered,
-    1,
-    Marko._.renderTemplate(__marko_internal_tag_1)()()({
-      value: input,
-    }),
-  );
+  const __marko_internal_rendered_1 = Marko._.renderTemplate(
+    __marko_internal_tag_1,
+  )()()({
+    value: input,
+  });
   const { year, isSmartOnly, type, mobileList, renderBody } =
-    Marko._.rendered.returns[1].value;
+    __marko_internal_rendered_1.return.value;
   Marko._.renderNativeTag("div")()()({
     class: "mobiles__list",
     ["renderBody" /*div*/]: (() => {

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -34,12 +34,6 @@ declare global {
         fn: (input: AttrTagNames<Input>) => void,
       ): void;
 
-      export const rendered: {
-        scopes: Record<number, never>;
-        returns: Record<number, never>;
-      };
-
-      export const tags: Record<number, unknown>;
       export const content: DefaultBodyContentKey;
 
       export function contentFor<Name>(
@@ -87,35 +81,19 @@ declare global {
         ? Instance
         : never;
 
-      export function readScopes<Rendered>(
-        rendered: Rendered,
-      ): MergeScopes<
-        Rendered extends { scopes: Record<any, infer Scope> } ? Scope : never
-      > &
-        Record<any, never>;
-
-      export function assertTag<Index extends number, Tags, Tag>(
-        tags: Tags,
-        index: Index,
-        tag: Tag,
-      ): asserts tags is Tags &
-        Record<Index, [0] extends [1 & Tag] ? any : Tag>;
-
-      export function assertRendered<Index extends number, Rendered, Result>(
-        rendered: Rendered,
-        index: Index,
-        result: Result,
-      ): asserts rendered is Rendered & {
-        scopes: Record<
-          Index,
-          MergeOptionalScopes<
-            Result extends { scope: infer Scope } ? Scope : undefined
-          >
-        >;
-        returns: Result extends { return?: infer Return }
-          ? Record<Index, Return>
-          : Record<Index, never>;
-      };
+      export function readScopes<Rendered>(rendered: Rendered): MergeScopes<
+        {
+          [K in keyof Rendered]: Rendered[K] extends infer Value
+            ? undefined extends Value
+              ? Value extends { scope: infer Scope }
+                ? Partial<Scope>
+                : never
+              : Value extends { scope: infer Scope }
+                ? Scope
+                : never
+            : never;
+        }[keyof Rendered]
+      >;
 
       export function mutable<Lookup>(lookup: Lookup): UnionToIntersection<
         Lookup extends readonly (infer Item)[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

- Fix setters to tag vars in parent scopes in presence of tag params

## Description

This was previously broken:
```marko
export interface Input {
  actions: string[]
}

<let/selected=""/>

<for|action| of=input.actions>
  <button onClick() { selected = action; } >
                   // ^? any (should be string)
    click
  </button>
</for>
```
