### PR TITLE
fix(ts): tag param for unreachable body

### DIFF
--- a/.changeset/violet-cougars-rescue.md
+++ b/.changeset/violet-cougars-rescue.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix tag vars in unreachable bodies

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.html
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.html
@@ -3,4 +3,7 @@
                   
     placeholder
   </button>
-</div>
+</div><div>
+  
+  <input data-marko-node-id="5" id="dynamic">
+</div><button data-marko-node-id="6" onClick>Body to prevent a11y error</button>

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.md
@@ -30,13 +30,13 @@
   7 |   </button>
 ```
 
-### Ln 18, Col 6
+### Ln 16, Col 6
 ```marko
-  16 |
-  17 | <button onClick() {
-> 18 |   inputId;
+  14 |
+  15 | <button onClick() {
+> 16 |   inputId;
      |      ^ const inputId: never
-  19 |   // ^?
-  20 | }>Body to prevent a11y error</button>
+  17 |   // ^?
+  18 | }>Body to prevent a11y error</button>
 ```
 

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.md
@@ -30,3 +30,13 @@
   7 |   </button>
 ```
 
+### Ln 18, Col 6
+```marko
+  16 |
+  17 | <button onClick() {
+> 18 |   inputId;
+     |      ^ const inputId: never
+  19 |   // ^?
+  20 | }>Body to prevent a11y error</button>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.ts
@@ -54,11 +54,7 @@ export { type Component };
     {
       /*for*/ of: [],
     },
-    (
-      // for this one we need to look in the compiled code 😬
-      // readScopes should include `inputId`
-      _unused,
-    ) => {
+    (_unused) => {
       const __marko_internal_tag_3 = Marko._.resolveTemplate(
         import("../../../components/let/index.marko"),
       );

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/index.ts
@@ -50,6 +50,50 @@ export { type Component };
       return Marko._.voidReturn;
     },
   });
+  const __marko_internal_rendered_2 = Marko._.forOfTag(
+    {
+      /*for*/ of: [],
+    },
+    (
+      // for this one we need to look in the compiled code 😬
+      // readScopes should include `inputId`
+      _unused,
+    ) => {
+      const __marko_internal_tag_3 = Marko._.resolveTemplate(
+        import("../../../components/let/index.marko"),
+      );
+      const __marko_internal_rendered_3 = Marko._.renderTemplate(
+        __marko_internal_tag_3,
+      )()()({
+        value: "",
+      });
+      const inputId = __marko_internal_rendered_3.return.value;
+      Marko._.renderNativeTag("input")()()({
+        id: inputId,
+      });
+      return new (class MarkoReturn<Return = void> {
+        [Marko._.scope] = { inputId };
+        declare return: Return;
+        constructor(_?: Return) {}
+      })();
+    },
+  );
+  Marko._.renderNativeTag("button")()()({
+    onClick() {
+      inputId;
+      // ^?
+    },
+    ["renderBody" /*button*/]: (() => {
+      return () => {
+        return Marko._.voidReturn;
+      };
+    })(),
+  });
+  const { inputId } = Marko._.readScopes({
+    __marko_internal_rendered_1,
+    __marko_internal_rendered_2,
+  });
+  Marko._.noop({ inputId });
   return;
 })();
 export default new (class Template extends Marko._.Template<{

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/index.marko
@@ -6,3 +6,13 @@
     ${val}
   </button>
 </test-tag>
+
+<for|_unused| of=[]>
+  <let/inputId=""/>
+  <input id=inputId>
+</for>
+
+<button onClick() {
+  inputId;
+  // ^?
+}>Body to prevent a11y error</button>

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -86,14 +86,19 @@ declare global {
           [K in keyof Rendered]: Rendered[K] extends infer Value
             ? undefined extends Value
               ? Value extends { scope: infer Scope }
-                ? Partial<Scope>
+                ? [0] extends [1 & Scope]
+                  ? never
+                  : Partial<Scope>
                 : never
               : Value extends { scope: infer Scope }
-                ? Scope
+                ? [0] extends [1 & Scope]
+                  ? never
+                  : Scope
                 : never
             : never;
         }[keyof Rendered]
-      >;
+      > &
+        Record<any, never>;
 
       export function mutable<Lookup>(lookup: Lookup): UnionToIntersection<
         Lookup extends readonly (infer Item)[]
@@ -152,7 +157,7 @@ declare global {
       >(input: Input): Input;
 
       export function forOfTag<
-        Value,
+        Value extends Iterable,
         Item extends Value extends
           | readonly (infer Item)[]
           | Iterable<infer Item>


### PR DESCRIPTION
## Description

- When a tag body was unreachable, an error was thrown elsewhere in the template after an attempt to hoist its tag vars.
```marko
<for|_bodyUnreachable| of=[]>
  <let/ts_will_try_to_hoist_this/>
</for>

<script>
  ts_will_try_to_hoist_this;
  // ^? Before this was `any`, now it's `never`
</script>
```