### PR TITLE
fix(script extractor): add semicolon

### DIFF
--- a/.changeset/tasty-carrots-compete.md
+++ b/.changeset/tasty-carrots-compete.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix semicolon bug

--- a/packages/language-tools/src/extractors/script/index.ts
+++ b/packages/language-tools/src/extractors/script/index.ts
@@ -1803,7 +1803,7 @@ constructor(_?: Return) {}
         this.#writeAttrTagTree(nested, `input["@${name}"]`, true);
       }
     }
-    this.#extractor.write(`})`);
+    this.#extractor.write(`});`);
   }
 
   #getAttrTagTree(tag: Node.Tag | Node.AttrTag, attrTags?: AttrTagTree) {


### PR DESCRIPTION
## Description

In some niche templates, the lack of a semicolon at the end of this statement causes problems

