### PR TITLE
fix(ts): for of undefined

### DIFF
--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/index.html
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/index.html
@@ -1,0 +1,15 @@
+<div>
+    
+  <a data-marko-node-id="1" href="dynamic">
+    placeholder
+    
+  </a>
+</div><select data-marko-node-id="2">
+  <div>
+      
+    <option data-marko-node-id="4" value="dynamic">
+      placeholder
+      
+    </option>
+  </div>
+</select>

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/index.md
@@ -1,0 +1,45 @@
+## Hovers
+### Ln 9, Col 8
+```marko
+   7 | }
+   8 |
+>  9 | <for|{ href, title }| of=input.tab>
+     |        ^ (parameter) href: string
+  10 |     // ^?
+  11 |   <a href=href>
+  12 |     ${title}
+```
+
+### Ln 12, Col 8
+```marko
+  10 |     // ^?
+  11 |   <a href=href>
+> 12 |     ${title}
+     |        ^ (parameter) title: string
+  13 |     // ^?
+  14 |   </a>
+  15 | </for>
+```
+
+### Ln 18, Col 10
+```marko
+  16 |
+  17 | <select>
+> 18 |   <for|{ value, content }| of=input.option>
+     |          ^ (parameter) value: any
+  19 |       // ^?
+  20 |     <option value=value>
+  21 |       ${content}
+```
+
+### Ln 21, Col 10
+```marko
+  19 |       // ^?
+  20 |     <option value=value>
+> 21 |       ${content}
+     |          ^ (parameter) content: any
+  22 |       // ^?
+  23 |     </option>
+  24 |   </for>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/index.ts
@@ -1,0 +1,102 @@
+export interface Input {
+  tab?: Marko.AttrTag<{
+    href: string;
+    title: string;
+  }>;
+  option: any;
+}
+abstract class Component extends Marko.Component<Input> {}
+export { type Component };
+(function (this: void) {
+  const input = Marko._.any as Input;
+  const component = Marko._.any as Component;
+  const state = Marko._.state(component);
+  const out = Marko._.out;
+  const $signal = Marko._.any as AbortSignal;
+  const $global = Marko._.getGlobal(
+    // @ts-expect-error We expect the compiler to error because we are checking if the MarkoRun.Context is defined.
+    (Marko._.error, Marko._.any as MarkoRun.Context),
+  );
+  Marko._.noop({ component, state, out, input, $global, $signal });
+  Marko._.forOfTag(
+    {
+      /*for*/ of: input.tab,
+    },
+    ({ href, title }) => {
+      Marko._.renderNativeTag("a")()()(
+        // ^?
+        {
+          href: href,
+          ["renderBody" /*a*/]: (() => {
+            title;
+            return () => {
+              return Marko._.voidReturn;
+            };
+          })(),
+        },
+      );
+      return Marko._.voidReturn;
+    },
+  );
+  Marko._.renderNativeTag("select")()()(
+    // ^?
+    {
+      ["renderBody" /*select*/]: (() => {
+        Marko._.forOfTag(
+          {
+            /*for*/ of: input.option,
+          },
+          ({ value, content }) => {
+            Marko._.renderNativeTag("option")()()(
+              // ^?
+              {
+                value: value,
+                ["renderBody" /*option*/]: (() => {
+                  content;
+                  return () => {
+                    return Marko._.voidReturn;
+                  };
+                })(),
+              },
+            );
+            return Marko._.voidReturn;
+          },
+        );
+        return () => {
+          return Marko._.voidReturn;
+        };
+      })(),
+    },
+  );
+  return;
+})();
+export default new (class Template extends Marko._.Template<{
+  render(
+    input: Marko.TemplateInput<Input>,
+    stream?: {
+      write: (chunk: string) => void;
+      end: (chunk?: string) => void;
+    },
+  ): Marko.Out<Component>;
+
+  render(
+    input: Marko.TemplateInput<Input>,
+    cb?: (err: Error | null, result: Marko.RenderResult<Component>) => void,
+  ): Marko.Out<Component>;
+
+  renderSync(input: Marko.TemplateInput<Input>): Marko.RenderResult<Component>;
+
+  renderToString(input: Marko.TemplateInput<Input>): string;
+
+  stream(
+    input: Marko.TemplateInput<Input>,
+  ): ReadableStream<string> & NodeJS.ReadableStream;
+
+  api: "class";
+  _(): () => <__marko_internal_input extends unknown>(
+    input: Marko.Directives &
+      Input &
+      Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
+  ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
+}> {})();
+// ^?

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-input/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-input/index.marko
@@ -1,0 +1,25 @@
+export interface Input {
+  tab?: Marko.AttrTag<{
+    href: string;
+    title: string;
+  }>;
+  option: any;
+}
+
+<for|{ href, title }| of=input.tab>
+    // ^?
+  <a href=href>
+    ${title}
+    // ^?
+  </a>
+</for>
+
+<select>
+  <for|{ value, content }| of=input.option>
+      // ^?
+    <option value=value>
+      ${content}
+      // ^?
+    </option>
+  </for>
+</select>

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -158,11 +158,11 @@ declare global {
 
       export function forOfTag<
         Value extends Iterable,
-        Item extends Value extends
-          | readonly (infer Item)[]
-          | Iterable<infer Item>
-          ? Item
-          : unknown,
+        Item extends [0] extends [1 & Value]
+          ? any
+          : Value extends readonly (infer Item)[] | Iterable<infer Item>
+            ? Item
+            : never,
         BodyContent extends Marko.Body<
           [item: Item, index: number, all: Value],
           void


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Scope

- The `<for>` tag _is_ allowed to include `undefined` in its `by=` attribute, but TS wasn't allowing it
- The same limitation also effected `<for of=1 as any>`