### PR TITLE
fix: change Record<*, unknown> to Record<*, any>

### DIFF
--- a/.changeset/ten-seas-shop.md
+++ b/.changeset/ten-seas-shop.md
@@ -1,0 +1,8 @@
+---
+"@marko/language-tools": patch
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Fix type stub issue

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -350,10 +350,7 @@ declare global {
         _: infer Renderer;
       }
         ? Renderer
-        : Template extends Marko.Template<
-              infer Input extends Record<string, unknown>,
-              infer Return
-            >
+        : Template extends Marko.Template<infer Input, infer Return>
           ? BaseRenderer<Input, Return>
           : never;
 
@@ -387,10 +384,7 @@ declare global {
         >;
       }
 
-      export interface BaseRenderer<
-        Input extends Record<PropertyKey, unknown>,
-        Return = void,
-      > {
+      export interface BaseRenderer<Input, Return = void> {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
         (): () => <__marko_input_with_scope extends unknown>(
           input: Marko.Directives &
@@ -400,9 +394,7 @@ declare global {
       }
 
       export interface DefaultRenderer {
-        (): () => <Input extends Record<PropertyKey, unknown>>(
-          input: Input,
-        ) => ReturnAndScope<Scopes<Input>, void>;
+        (): () => <Input>(input: Input) => ReturnAndScope<Scopes<Input>, void>;
       }
 
       export type Relate<A, B> = B extends A ? A : B;
@@ -439,9 +431,7 @@ type BodyContentInput<Args extends readonly unknown[]> = Args extends {
 
 type Scopes<Input> = [0] extends [1 & Input]
   ? never
-  : Input extends Record<any, unknown>
-    ? MergeScopes<FlatScopes<Input>>
-    : never;
+  : MergeScopes<FlatScopes<Input>>;
 
 type ComponentEventHandlers<Component extends Marko.Component> = {
   [K in Exclude<


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- As it turns out, interfaces do _not_ extend `Record<string, unknown>` but they do extend `Record<string, any>` ([TS Playground example](https://www.typescriptlang.org/play/?ts=5.8.3#code/C4TwDgpgBAKhDOwA8MB8UC8soQB7AgDsATeKAJQgGMB7AJ2KUToEtCBzAGigFdCBrQjQDuhdAH4oARigAuKAAYAUErYE6AMwCGVaAElC67bqgBvJVEtQNNGvOZt2SgL4rQkWOGhZzVqFvtgVg4XNy8oAEFMWARkAyMdCFQlAHoUqwA9cTCPACFouEQUL2S0zOygA))
- This impacted type stubs like this
    ```ts
    declare module "@module/src/index.marko" {
      interface MyInput {
        foo: string;
        bar: number;
      }
  
      const file: Template<MyInput>;
      export default file;
    }
    ```
- After switching from `unknown` to `any`, these type stubs seem to work properly
