### PR TITLE
feat: support tag import shorthands in ts files

### DIFF
--- a/.changeset/witty-ghosts-pump.md
+++ b/.changeset/witty-ghosts-pump.md
@@ -1,0 +1,7 @@
+---
+"@marko/language-server": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Support resolving tag import shorthands in typescript files.

--- a/packages/language-server/src/service/marko/complete/Import.ts
+++ b/packages/language-server/src/service/marko/complete/Import.ts
@@ -1,17 +1,22 @@
-import type { Node } from "@marko/language-tools";
+import { type Node, NodeType } from "@marko/language-tools";
 import { CompletionItem, TextEdit } from "vscode-languageserver";
 
 import getTagNameCompletion from "../util/get-tag-name-completion";
 import type { CompletionMeta, CompletionResult } from ".";
 
+const staticImportReg = /^\s*(?:static|client|server) import\b/;
 const importTagReg = /(['"])<((?:[^'"\\>]|\\.)*)>?\1/;
 
 export function Import({
   node,
   file: { parsed, filename, lookup },
-}: CompletionMeta<Node.Import>): CompletionResult {
-  // check for import statement
+}: CompletionMeta<Node.Import | Node.Static>): CompletionResult {
   const value = parsed.read(node);
+  if (node.type === NodeType.Static && !staticImportReg.test(value)) {
+    // Checks for `static import`, `client import` and `server import`.
+    return;
+  }
+
   const match = importTagReg.exec(value);
   if (match) {
     const [{ length }] = match;

--- a/packages/language-server/src/service/marko/complete/index.ts
+++ b/packages/language-server/src/service/marko/complete/index.ts
@@ -26,6 +26,7 @@ const handlers: Record<
   AttrName,
   AttrValue,
   Import,
+  Static: Import,
 };
 
 export const doComplete: Plugin["doComplete"] = async (doc, params) => {


### PR DESCRIPTION
Adds support for the import tag shorthand in typescript / js files.
```
import Tag from "<tag>";
```