### PR TITLE
feat: add generate trace api for mtc

### DIFF
--- a/.changeset/open-mails-lick.md
+++ b/.changeset/open-mails-lick.md
@@ -1,0 +1,6 @@
+---
+"@marko/language-server": minor
+"@marko/type-check": minor
+---
+
+Add generateTrace api.

--- a/packages/language-server/src/service/script/index.ts
+++ b/packages/language-server/src/service/script/index.ts
@@ -55,6 +55,9 @@ const optionalModifierReg = /\boptional\b/;
 const deprecatedModifierReg = /\bdeprecated\b/;
 const colorModifierReg = /\bcolor\b/;
 const localInternalsPrefix = "__marko_internal_";
+const getCanonicalFileName = ts.sys.useCaseSensitiveFileNames
+  ? (fileName: string) => fileName
+  : (fileName: string) => fileName.toLocaleLowerCase();
 const requiredTSCompilerOptions: ts.CompilerOptions = {
   module: ts.ModuleKind.ESNext,
   moduleResolution: ts.ModuleResolutionKind.Bundler,
@@ -1008,10 +1011,6 @@ function convertCompletionItemKind(kind: ts.ScriptElementKind) {
 function getTSTriggerChar(char: string | undefined) {
   if (char && tsTriggerChars.has(char))
     return char as ts.CompletionsTriggerCharacter;
-}
-
-function getCanonicalFileName(fileName: string) {
-  return ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
 }
 
 export { ScriptService as default };

--- a/packages/type-check/src/cli.ts
+++ b/packages/type-check/src/cli.ts
@@ -12,6 +12,7 @@ const args = arg(
   {
     "--project": String,
     "--display": String,
+    "--generateTrace": String,
     "--help": Boolean,
     "--version": Boolean,
     "-p": "--project",
@@ -72,6 +73,7 @@ For more information, visit ${color.blue(
   );
 } else {
   const {
+    "--generateTrace": generateTrace,
     "--display": display = process.env.CI
       ? Display.condensed
       : Display.codeframe,
@@ -86,7 +88,7 @@ For more information, visit ${color.blue(
   }
 
   checkDisplay(display);
-  run({ project, display });
+  run({ generateTrace, project, display });
 }
 
 function checkDisplay(


### PR DESCRIPTION
Adds support for a `--generateTrace DIR_NAME` `mtc` flag, analogous to https://www.typescriptlang.org/docs/handbook/compiler-options.html#compiler-options:~:text=run%20for%20debugging.-,%2D%2DgenerateTrace,-string