### PR TITLE
chore: fix for-of types

### DIFF
--- a/.changeset/few-oranges-juggle.md
+++ b/.changeset/few-oranges-juggle.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-tools": patch
+---
+
+Update Type definitions for for-of loop

--- a/packages/language-tools/marko.internal.d.ts
+++ b/packages/language-tools/marko.internal.d.ts
@@ -170,7 +170,7 @@ declare global {
       >(
         input: {
           of: Value | false | void | null;
-          by?: (item: Item, index: number) => string;
+          by?: ((item: Item, index: number) => string) | string;
         },
         content: BodyContent,
       ): ReturnAndScope<BodyContentScope<BodyContent>, void>;


### PR DESCRIPTION
## Scope

`@marko/language-tools`

## Description

Marko 6 supports writing:
```
<for|user| of=users by="id">
  ${user.firstName} ${user.lastName}
</for>
```

as shorthand for
```
<for|user| of=users by=user => user.id>
  ${user.firstName} ${user.lastName}
</for>
```

But the Typescript definitions do not reflect this.

## Motivation and Context

To fix Typescript definitions