### PR TITLE
fix: broken types in standalone language server

### DIFF
--- a/.changeset/fancy-numbers-chew.md
+++ b/.changeset/fancy-numbers-chew.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-server": patch
+---
+
+Fix broken types in standalone language server

--- a/packages/language-server/build.mts
+++ b/packages/language-server/build.mts
@@ -1,6 +1,12 @@
 import { build, BuildOptions } from "esbuild";
+import fs from "fs/promises";
+import { createRequire } from "module";
 import path from "path";
 import { fileURLToPath } from "url";
+
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.join(thisDir, "dist");
+const require = createRequire(import.meta.url);
 
 const opts: BuildOptions = {
   bundle: true,
@@ -10,7 +16,7 @@ const opts: BuildOptions = {
   target: ["node20"],
   sourcemap: "linked",
   entryPoints: ["src/index.ts"],
-  absWorkingDir: path.dirname(fileURLToPath(import.meta.url)),
+  absWorkingDir: thisDir,
   plugins: [
     {
       name: "external-modules",
@@ -28,6 +34,14 @@ const opts: BuildOptions = {
 };
 
 await Promise.all([
+  fs.copyFile(
+    path.join(thisDir, "../language-tools/marko.internal.d.ts"),
+    path.join(distDir, "marko.internal.d.ts"),
+  ),
+  fs.copyFile(
+    path.join(require.resolve("marko/package.json"), "../index.d.ts"),
+    path.join(distDir, "marko.runtime.d.ts"),
+  ),
   build({
     ...opts,
     format: "cjs",


### PR DESCRIPTION
Currently LSP only works in vscode, in other editors type inference is broken because the build script is incorrect, this fixes that.

build.mts between language-server and vscode plugins is partially duplicated, this is error prone as you can see this by this example, would be nice to share the build process (I probably should create an issue for this?).