### PR TITLE
feat: expose ts plugin as a package for other editors to use

### DIFF
--- a/.changeset/marko-ts-plugin.md
+++ b/.changeset/marko-ts-plugin.md
@@ -1,0 +1,5 @@
+---
+"@marko/ts-plugin": minor
+---
+
+Add `@marko/ts-plugin`, a standalone TypeScript Server plugin that resolves Marko (`.marko`) imports with types inside `.ts`/`.tsx` files. It packages the same plugin the VS Code extension bundles so other editors (Zed, Neovim, ...) can register it with their TypeScript server.

--- a/cspell.json
+++ b/cspell.json
@@ -53,6 +53,7 @@
     "taglibs",
     "tsserverlibrary",
     "vscodeignore",
+    "vtsls",
     "vwong",
     "Webstorm"
   ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,13 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig(
   {
-    ignores: [".vscode", "coverage", "**/dist", "**/__snapshots__"],
+    ignores: [
+      ".vscode",
+      "**/.vscode-test",
+      "coverage",
+      "**/dist",
+      "**/__snapshots__",
+    ],
   },
   eslint.configs.recommended,
   tseslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2190,6 +2190,10 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/@marko/ts-plugin": {
+      "resolved": "packages/ts-plugin",
+      "link": true
+    },
     "node_modules/@marko/type-check": {
       "resolved": "packages/type-check",
       "link": true
@@ -11259,6 +11263,18 @@
         "marko": "^5.38.36",
         "mitata": "^1.0.34",
         "tsx": "^4.21.0"
+      }
+    },
+    "packages/ts-plugin": {
+      "name": "@marko/ts-plugin",
+      "version": "3.0.1",
+      "license": "MIT",
+      "devDependencies": {
+        "@marko/language-server": "^3.0.1",
+        "@marko/language-tools": "^2.5.59",
+        "marko": "^5.38.36",
+        "tsx": "^4.21.0",
+        "typescript": "^6.0.3"
       }
     },
     "packages/type-check": {

--- a/packages/ts-plugin/README.md
+++ b/packages/ts-plugin/README.md
@@ -1,0 +1,29 @@
+# @marko/ts-plugin
+
+A [TypeScript Server plugin](https://www.typescriptlang.org/tsconfig/#plugins)
+that teaches TypeScript to resolve Marko (`.marko`) imports with real types
+from inside `.ts`/`.tsx` files. It is the same plugin the
+[Marko VS Code extension](https://github.com/marko-js/language-server) bundles,
+published standalone so other editors can register it with their TypeScript
+server.
+
+## Usage
+
+Add it to a project's `tsconfig.json`:
+
+```jsonc
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "@marko/ts-plugin" }],
+  },
+}
+```
+
+This enables types for `import Component from "./component.marko"` when the
+editor uses the workspace TypeScript version.
+
+Editors that run their own TypeScript server (vtsls, typescript-language-server)
+can load it as a global plugin instead of per-project. The Marko VS Code
+extension registers it automatically; the Zed extension
+([marko-js/zed](https://github.com/marko-js/zed)) does the same via its
+TypeScript language-server configuration.

--- a/packages/ts-plugin/build.mts
+++ b/packages/ts-plugin/build.mts
@@ -1,4 +1,4 @@
-import { analyzeMetafile, build } from "esbuild";
+import { build } from "esbuild";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -18,29 +18,14 @@ await build({
   minify: isProd,
   sourcesContent: false,
   absWorkingDir: thisDir,
-  metafile: true,
   format: "cjs",
   outdir: "dist",
+  outbase: "src",
   platform: "node",
   target: ["node16"],
   sourcemap: "linked",
-  entryPoints: [
-    { in: "src/index.ts", out: "index" },
-    { in: "src/server.ts", out: "server" },
-    // The TypeScript Server plugin is the shared @marko/ts-plugin entry; it is
-    // bundled into dist/ts-plugin.js and exposed via modules/marko-ts-plugin.
-    { in: "../ts-plugin/src/index.ts", out: "ts-plugin" },
-    { in: "src/__tests__/index.ts", out: "__tests__/index" },
-  ],
-  external: [
-    "vscode",
-    "mocha",
-    "mocha-snap",
-    "fast-glob",
-    "tsx",
-    "canvas",
-    "browserslist",
-  ],
+  entryPoints: ["src/index.ts"],
+  external: ["canvas", "browserslist"],
   define: {
     "import.meta.url": "_importMetaUrl",
   },
@@ -48,8 +33,4 @@ await build({
     js: "const _importMetaUrl = require('url').pathToFileURL(__filename);",
   },
   plugins: markoBundlePlugins,
-}).then(async (result) => {
-  if (isProd) {
-    console.log(await analyzeMetafile(result.metafile));
-  }
 });

--- a/packages/ts-plugin/package.json
+++ b/packages/ts-plugin/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@marko/ts-plugin",
+  "version": "3.0.1",
+  "description": "TypeScript Server plugin that resolves Marko (.marko) imports with types inside TypeScript files",
+  "keywords": [
+    "marko",
+    "typescript",
+    "tsserver",
+    "plugin",
+    "tools"
+  ],
+  "homepage": "https://github.com/marko-js/language-server/tree/main/packages/ts-plugin/README.md",
+  "bugs": "https://github.com/marko-js/language-server/issues/new?template=bug-report.yml",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/marko-js/language-server/tree/main/packages/ts-plugin"
+  },
+  "license": "MIT",
+  "main": "dist/index.js",
+  "files": [
+    "dist",
+    "!**/__tests__",
+    "!**/*.tsbuildinfo"
+  ],
+  "scripts": {
+    "build": "tsx build.mts"
+  },
+  "devDependencies": {
+    "@marko/language-server": "^3.0.1",
+    "@marko/language-tools": "^2.5.59",
+    "marko": "^5.38.36",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/packages/ts-plugin/src/index.ts
+++ b/packages/ts-plugin/src/index.ts
@@ -1,0 +1,7 @@
+import { init } from "../../language-server/src/ts-plugin";
+
+// CommonJS export so the TypeScript Server can load this module as a plugin
+// (`compilerOptions.plugins: [{ name: "@marko/ts-plugin" }]`). This is the same
+// plugin the Marko VS Code extension bundles, published standalone so other
+// editors (Zed, Neovim, ...) can register it with their TypeScript server.
+export = init;

--- a/packages/ts-plugin/tsconfig.json
+++ b/packages/ts-plugin/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["**/__tests__"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "references": [
+    { "path": "../language-server" },
+    { "path": "../language-tools" }
+  ]
+}

--- a/packages/vscode/src/ts-plugin.ts
+++ b/packages/vscode/src/ts-plugin.ts
@@ -1,5 +1,0 @@
-import { init } from "../../language-server/src/ts-plugin";
-
-// Explicitly use commonjs here to avoid the typescript error:
-// eventually should be resolved by https://github.com/microsoft/TypeScript/issues/49270
-export = init;

--- a/scripts/marko-esbuild.mts
+++ b/scripts/marko-esbuild.mts
@@ -1,0 +1,98 @@
+// Shared esbuild pieces for bundles that embed the Marko TypeScript tooling
+// (the language server and the @marko/ts-plugin). Both bundle typescript and
+// @marko/language-tools, so they need the same dependency fixups and the same
+// runtime asset copying.
+import type { Plugin } from "esbuild";
+import fs from "fs/promises";
+import { createRequire } from "module";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const packagesDir = path.join(here, "../packages");
+const require = createRequire(import.meta.url);
+
+// typescript is bundled (via @marko/language-tools), so the lib.*.d.ts and the
+// Marko type-def files must sit next to the bundle; the runtime resolves them
+// relative to its own __dirname.
+export async function copyMarkoBundleAssets(distDir: string): Promise<void> {
+  await fs.mkdir(distDir, { recursive: true });
+  const tsLibDir = path.join(
+    require.resolve("typescript/package.json"),
+    "../lib",
+  );
+  await Promise.all([
+    (async () => {
+      const dir = await fs.opendir(tsLibDir);
+      for await (const entry of dir) {
+        if (entry.isFile() && /^lib\..*\.d\.ts$/.test(entry.name)) {
+          await fs.copyFile(
+            path.join(tsLibDir, entry.name),
+            path.join(distDir, entry.name),
+          );
+        }
+      }
+    })(),
+    fs.copyFile(
+      path.join(packagesDir, "language-tools/marko.internal.d.ts"),
+      path.join(distDir, "marko.internal.d.ts"),
+    ),
+    fs.copyFile(
+      path.join(require.resolve("marko/package.json"), "../index.d.ts"),
+      path.join(distDir, "marko.runtime.d.ts"),
+    ),
+  ]);
+}
+
+// esbuild plugins shared by the Marko bundles: resolve @marko/language-tools to
+// its source and work around a few dependencies that don't bundle cleanly.
+export const markoBundlePlugins: Plugin[] = [
+  {
+    name: "vscode-css-languageservice-fix",
+    setup(build) {
+      // alias vscode-css-languageservice to its esm version; the default is a
+      // UMD definition that's incompatible with esbuild.
+      const pkg = "vscode-css-languageservice/package.json";
+      build.onResolve({ filter: /^vscode-css-languageservice$/ }, () => ({
+        path: path.join(
+          require.resolve(pkg),
+          "..",
+          require(pkg).module as string,
+        ),
+      }));
+    },
+  },
+  {
+    name: "marko-language-tools-fix",
+    setup(build) {
+      build.onResolve({ filter: /^@marko\/language-tools$/ }, () => ({
+        path: path.join(packagesDir, "language-tools/src/index.ts"),
+      }));
+    },
+  },
+  {
+    name: "jsdom-fix",
+    setup(build) {
+      build.onLoad(
+        { filter: /\/jsdom\/.*\/XMLHttpRequest-impl\.js$/ },
+        async (args) => ({
+          loader: "js",
+          contents: (await fs.readFile(args.path, "utf8")).replace(
+            'require.resolve ? require.resolve("./xhr-sync-worker.js") :',
+            "",
+          ),
+        }),
+      );
+    },
+  },
+  {
+    name: "prettier-optimize",
+    setup(build) {
+      build.onLoad({ filter: /\/prettier\/plugins\/.*$/ }, async (args) => {
+        if (!/\/(babel|estree|postcss|typescript)\.m?js$/.test(args.path)) {
+          return { contents: "", loader: "js" };
+        }
+      });
+    },
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./packages/language-tools" },
     { "path": "./packages/language-server" },
+    { "path": "./packages/ts-plugin" },
     { "path": "./packages/type-check" },
     { "path": "./packages/vscode" }
   ]


### PR DESCRIPTION
Add `@marko/ts-plugin`, a standalone TypeScript Server plugin that resolves Marko (`.marko`) imports with types inside `.ts`/`.tsx` files. It packages the same plugin the VS Code extension bundles so other editors (Zed, Neovim, ...) can register it with their TypeScript server.