### PR TITLE
feat: surface compiler diagnostic fixes as code actions

### DIFF
--- a/.changeset/marko-diagnostic-quick-fixes.md
+++ b/.changeset/marko-diagnostic-quick-fixes.md
@@ -1,0 +1,10 @@
+---
+"@marko/language-server": minor
+---
+
+Surface Marko compiler diagnostic fixes as in-editor code actions. Compiler plugins can attach a `fix` to a diagnostic (an in-place AST edit, e.g. the `data` -> `input` migration), and the language server now offers these as:
+
+- per-diagnostic `quickfix` actions, and
+- a batched `source.fixAll.marko` source action that applies every auto-fixable issue in a single compile pass — so it plugs into VS Code's "Fix All" command and `editor.codeActionsOnSave`.
+
+Applying a fix re-runs the compiler asking it to apply the relevant fix(es), reprints the result, formats it with prettier, and produces a minimal text edit so the rest of the document is left untouched. Edits are resolved lazily via `codeAction/resolve` (when the client supports it) and the diagnostics compile is shared with validation, so nothing extra is compiled until a fix is actually used.

--- a/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/__snapshots__/data-deprecation.expected/index.html
+++ b/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/__snapshots__/data-deprecation.expected/index.html
@@ -1,0 +1,3 @@
+<div data-marko-node-id="0" class="dynamic">
+  Hello placeholder!
+</div>

--- a/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/__snapshots__/data-deprecation.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/__snapshots__/data-deprecation.expected/index.md
@@ -1,0 +1,59 @@
+## Diagnostics
+### Ln 1, Col 12
+```marko
+> 1 | <div class=data.className>
+    |            ^^^^ The 'data' variable is deprecated. Use 'input' instead.
+  2 |   Hello ${data.name}!
+  3 | </div>
+  4 |
+```
+
+### Ln 2, Col 11
+```marko
+  1 | <div class=data.className>
+> 2 |   Hello ${data.name}!
+    |           ^^^^ The 'data' variable is deprecated. Use 'input' instead.
+  3 | </div>
+  4 |
+```
+
+### Ln 1, Col 12
+```marko
+> 1 | <div class=data.className>
+    |            ^^^^ Cannot find name 'data'.
+  2 |   Hello ${data.name}!
+  3 | </div>
+  4 |
+```
+
+### Ln 2, Col 11
+```marko
+  1 | <div class=data.className>
+> 2 |   Hello ${data.name}!
+    |           ^^^^ Cannot find name 'data'.
+  3 | </div>
+  4 |
+```
+
+## Code Actions
+### The 'data' variable is deprecated. Use 'input' instead.
+```marko
+<div class=input.className>
+  Hello ${data.name}!
+</div>
+```
+
+### The 'data' variable is deprecated. Use 'input' instead.
+```marko
+<div class=data.className>
+  Hello ${input.name}!
+</div>
+```
+
+### Fix all auto-fixable Marko issues
+```marko
+<div class=input.className>
+  Hello ${input.name}!
+</div>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/__snapshots__/data-deprecation.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/__snapshots__/data-deprecation.expected/index.ts
@@ -1,0 +1,62 @@
+export interface Input {}
+abstract class Component extends Marko.Component<Input> {}
+export { type Component };
+(function (this: void) {
+  const input = Marko._.any as Input;
+  const component = Marko._.any as Component;
+  const state = Marko._.state(component);
+  const out = Marko._.any as Marko.Out;
+  const $signal = Marko._.any as AbortSignal;
+  const $global = Marko._.getGlobal(
+    // @ts-expect-error We expect the compiler to error because we are checking if the MarkoRun.Context is defined.
+    (Marko._.error, Marko._.any as MarkoRun.Context),
+  );
+  Marko._.renderNativeTag("div")()()({
+    class: data.className,
+    [Marko._.content]: (() => {
+      data.name;
+      return () => {
+        return Marko._.voidReturn;
+      };
+    })(),
+  });
+  Marko._.noop({ component, state, out, input, $global, $signal });
+  return;
+})();
+const __marko_internal_api = "class";
+export { __marko_internal_api as "~api" };
+export default new (class Template extends Marko._.Template<{
+  render(
+    input: Marko.TemplateInput<Input>,
+    stream?: {
+      write: (chunk: string) => void;
+      end: (chunk?: string) => void;
+    },
+  ): Marko.Out<Component>;
+
+  render(
+    input: Marko.TemplateInput<Input>,
+    cb?: (err: Error | null, result: Marko.RenderResult<Component>) => void,
+  ): Marko.Out<Component>;
+
+  renderSync(input: Marko.TemplateInput<Input>): Marko.RenderResult<Component>;
+
+  renderToString(input: Marko.TemplateInput<Input>): string;
+
+  stream(
+    input: Marko.TemplateInput<Input>,
+  ): ReadableStream<string> & NodeJS.ReadableStream;
+
+  mount(
+    input: Marko.TemplateInput<Input>,
+    reference: Node,
+    position?: "afterbegin" | "afterend" | "beforebegin" | "beforeend",
+  ): Marko.MountedTemplate<typeof input>;
+
+  api: typeof __marko_internal_api;
+  _(): () => <__marko_internal_input extends unknown>(
+    input: Marko.Directives &
+      Input &
+      Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
+  ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
+}> {})();

--- a/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/code-action/data-deprecation/index.marko
@@ -1,0 +1,3 @@
+<div class=data.className>
+  Hello ${data.name}!
+</div>

--- a/packages/language-server/src/__tests__/fixtures/code-action/fix-all/__snapshots__/fix-all.expected/index.html
+++ b/packages/language-server/src/__tests__/fixtures/code-action/fix-all/__snapshots__/fix-all.expected/index.html
@@ -1,0 +1,3 @@
+<div data-marko-node-id="0" class="dynamic">
+  Showing placeholder and placeholder
+</div>

--- a/packages/language-server/src/__tests__/fixtures/code-action/fix-all/__snapshots__/fix-all.expected/index.md
+++ b/packages/language-server/src/__tests__/fixtures/code-action/fix-all/__snapshots__/fix-all.expected/index.md
@@ -1,0 +1,84 @@
+## Diagnostics
+### Ln 1, Col 12
+```marko
+> 1 | <div class=data.theme>
+    |            ^^^^ The 'data' variable is deprecated. Use 'input' instead.
+  2 |   Showing ${data.title} and ${data.body}
+  3 | </div>
+  4 |
+```
+
+### Ln 2, Col 13
+```marko
+  1 | <div class=data.theme>
+> 2 |   Showing ${data.title} and ${data.body}
+    |             ^^^^ The 'data' variable is deprecated. Use 'input' instead.
+  3 | </div>
+  4 |
+```
+
+### Ln 2, Col 31
+```marko
+  1 | <div class=data.theme>
+> 2 |   Showing ${data.title} and ${data.body}
+    |                               ^^^^ The 'data' variable is deprecated. Use 'input' instead.
+  3 | </div>
+  4 |
+```
+
+### Ln 1, Col 12
+```marko
+> 1 | <div class=data.theme>
+    |            ^^^^ Cannot find name 'data'.
+  2 |   Showing ${data.title} and ${data.body}
+  3 | </div>
+  4 |
+```
+
+### Ln 2, Col 13
+```marko
+  1 | <div class=data.theme>
+> 2 |   Showing ${data.title} and ${data.body}
+    |             ^^^^ Cannot find name 'data'.
+  3 | </div>
+  4 |
+```
+
+### Ln 2, Col 31
+```marko
+  1 | <div class=data.theme>
+> 2 |   Showing ${data.title} and ${data.body}
+    |                               ^^^^ Cannot find name 'data'.
+  3 | </div>
+  4 |
+```
+
+## Code Actions
+### The 'data' variable is deprecated. Use 'input' instead.
+```marko
+<div class=input.theme>
+  Showing ${data.title} and ${data.body}
+</div>
+```
+
+### The 'data' variable is deprecated. Use 'input' instead.
+```marko
+<div class=data.theme>
+  Showing ${input.title} and ${data.body}
+</div>
+```
+
+### The 'data' variable is deprecated. Use 'input' instead.
+```marko
+<div class=data.theme>
+  Showing ${data.title} and ${input.body}
+</div>
+```
+
+### Fix all auto-fixable Marko issues
+```marko
+<div class=input.theme>
+  Showing ${input.title} and ${input.body}
+</div>
+```
+

--- a/packages/language-server/src/__tests__/fixtures/code-action/fix-all/__snapshots__/fix-all.expected/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/code-action/fix-all/__snapshots__/fix-all.expected/index.ts
@@ -1,0 +1,63 @@
+export interface Input {}
+abstract class Component extends Marko.Component<Input> {}
+export { type Component };
+(function (this: void) {
+  const input = Marko._.any as Input;
+  const component = Marko._.any as Component;
+  const state = Marko._.state(component);
+  const out = Marko._.any as Marko.Out;
+  const $signal = Marko._.any as AbortSignal;
+  const $global = Marko._.getGlobal(
+    // @ts-expect-error We expect the compiler to error because we are checking if the MarkoRun.Context is defined.
+    (Marko._.error, Marko._.any as MarkoRun.Context),
+  );
+  Marko._.renderNativeTag("div")()()({
+    class: data.theme,
+    [Marko._.content]: (() => {
+      data.title;
+      data.body;
+      return () => {
+        return Marko._.voidReturn;
+      };
+    })(),
+  });
+  Marko._.noop({ component, state, out, input, $global, $signal });
+  return;
+})();
+const __marko_internal_api = "class";
+export { __marko_internal_api as "~api" };
+export default new (class Template extends Marko._.Template<{
+  render(
+    input: Marko.TemplateInput<Input>,
+    stream?: {
+      write: (chunk: string) => void;
+      end: (chunk?: string) => void;
+    },
+  ): Marko.Out<Component>;
+
+  render(
+    input: Marko.TemplateInput<Input>,
+    cb?: (err: Error | null, result: Marko.RenderResult<Component>) => void,
+  ): Marko.Out<Component>;
+
+  renderSync(input: Marko.TemplateInput<Input>): Marko.RenderResult<Component>;
+
+  renderToString(input: Marko.TemplateInput<Input>): string;
+
+  stream(
+    input: Marko.TemplateInput<Input>,
+  ): ReadableStream<string> & NodeJS.ReadableStream;
+
+  mount(
+    input: Marko.TemplateInput<Input>,
+    reference: Node,
+    position?: "afterbegin" | "afterend" | "beforebegin" | "beforeend",
+  ): Marko.MountedTemplate<typeof input>;
+
+  api: typeof __marko_internal_api;
+  _(): () => <__marko_internal_input extends unknown>(
+    input: Marko.Directives &
+      Input &
+      Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
+  ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
+}> {})();

--- a/packages/language-server/src/__tests__/fixtures/code-action/fix-all/index.marko
+++ b/packages/language-server/src/__tests__/fixtures/code-action/fix-all/index.marko
@@ -1,0 +1,3 @@
+<div class=data.theme>
+  Showing ${data.title} and ${data.body}
+</div>

--- a/packages/language-server/src/__tests__/index.test.ts
+++ b/packages/language-server/src/__tests__/index.test.ts
@@ -1,13 +1,26 @@
+import assert from "node:assert/strict";
+
+import type { Diagnostic as CompilerDiagnostic } from "@marko/compiler/babel-utils";
 import { Project } from "@marko/language-tools";
 import fs from "fs";
 import snapshot from "mocha-snap";
 import path from "path";
-import { CancellationToken, Position } from "vscode-languageserver";
+import {
+  CancellationToken,
+  Command,
+  type InitializeParams,
+  Position,
+} from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 // import { bench, run } from "mitata";
 import { URI } from "vscode-uri";
 
 import MarkoLanguageService, { documents } from "../service";
+import MarkoPlugin from "../service/marko";
+import {
+  collectBatchFixes,
+  getFixCandidates,
+} from "../service/marko/code-actions";
 import { codeFrame } from "./util/code-frame";
 
 Project.setDefaultTypePaths({
@@ -15,6 +28,14 @@ Project.setDefaultTypePaths({
     require.resolve("@marko/language-tools/marko.internal.d.ts"),
   markoTypesFile: require.resolve("marko/index.d.ts"),
 });
+
+// Advertise client-side code action resolve support so fixes are exercised
+// through the lazy resolve path (`doCodeActions` -> `doCodeActionResolve`).
+MarkoPlugin.initialize?.({
+  capabilities: {
+    textDocument: { codeAction: { resolveSupport: { properties: ["edit"] } } },
+  },
+} as InitializeParams);
 
 // const SHOULD_BENCH = process.env.BENCH;
 // const BENCHED = new Set<string>();
@@ -136,6 +157,36 @@ for (const subdir of fs.readdirSync(FIXTURE_DIR)) {
           }
         }
 
+        const codeActions = await MarkoLanguageService.doCodeActions(
+          doc,
+          {
+            textDocument: { uri: doc.uri },
+            range: {
+              start: doc.positionAt(0),
+              end: doc.positionAt(code.length),
+            },
+            context: { diagnostics: errors || [] },
+          },
+          CancellationToken.None,
+        );
+
+        let codeActionResults = "";
+        for (const action of codeActions || []) {
+          if (Command.is(action)) continue;
+          const resolved =
+            (await MarkoLanguageService.doCodeActionResolve(
+              action,
+              CancellationToken.None,
+            )) || action;
+          const edits = resolved.edit?.changes?.[doc.uri] || [];
+          const fixed = TextDocument.applyEdits(doc, edits);
+          codeActionResults += `### ${resolved.title}\n\`\`\`marko\n${fixed}\n\`\`\`\n\n`;
+        }
+
+        if (codeActionResults) {
+          results += `## Code Actions\n${codeActionResults}`;
+        }
+
         documents.doClose(params);
 
         await snapshot(results, {
@@ -154,6 +205,94 @@ for (const subdir of fs.readdirSync(FIXTURE_DIR)) {
 //     await run();
 //   });
 // }
+
+describe("code action kind filtering", () => {
+  const file = path.join(FIXTURE_DIR, "code-action", "fix-all", "index.marko");
+  const uri = URI.file(file).toString();
+  const content = fs.readFileSync(file, "utf-8");
+  const doc = TextDocument.create(uri, "marko", 1, content);
+  const range = {
+    start: { line: 0, character: 0 },
+    end: doc.positionAt(content.length),
+  };
+
+  const kindsFor = async (only?: string[]) => {
+    const actions = await MarkoLanguageService.doCodeActions(
+      doc,
+      { textDocument: { uri }, range, context: { diagnostics: [], only } },
+      CancellationToken.None,
+    );
+    return (actions || []).map((action) =>
+      Command.is(action) ? "command" : action.kind,
+    );
+  };
+
+  it("offers both quick fixes and fix-all when unfiltered", async () => {
+    const kinds = await kindsFor();
+    assert.ok(kinds.includes("quickfix"), "expected quick fixes");
+    assert.ok(kinds.includes("source.fixAll.marko"), "expected a fix-all");
+  });
+
+  it("offers only quick fixes when `quickfix` is requested", async () => {
+    const kinds = await kindsFor(["quickfix"]);
+    assert.ok(kinds.length > 0);
+    assert.ok(kinds.every((kind) => kind === "quickfix"));
+  });
+
+  it("offers only fix-all when `source.fixAll` is requested", async () => {
+    // A generic `source.fixAll` request matches our `source.fixAll.marko`
+    // action via kind hierarchy -- this is what VS Code's "Fix All" uses.
+    assert.deepEqual(await kindsFor(["source.fixAll"]), [
+      "source.fixAll.marko",
+    ]);
+  });
+});
+
+describe("diagnostic fix prompts", () => {
+  // A compiler fix is either an automatic function fix (`true`) or an
+  // interactive `confirm`/`select` prompt. None ship in marko 5 yet, so the
+  // prompt mapping is verified here against synthetic diagnostics.
+  const diag = (fix: unknown, label = "msg") =>
+    ({ type: "deprecation", label, loc: false, fix }) as CompilerDiagnostic;
+
+  it("maps an automatic function fix to a single preferred quick fix", () => {
+    assert.deepEqual(getFixCandidates(diag(true, "Use input")), [
+      { title: "Use input", value: undefined, isPreferred: true },
+    ]);
+  });
+
+  it("maps a confirm prompt to a single non-preferred 'yes' action", () => {
+    const fix = { type: "confirm", message: "Convert?", initialValue: false };
+    assert.deepEqual(getFixCandidates(diag(fix)), [
+      { title: "Convert?", value: true, isPreferred: false },
+    ]);
+  });
+
+  it("maps a select prompt to one non-preferred action per option", () => {
+    const fix = {
+      type: "select",
+      message: "Pick",
+      options: [{ value: "a", label: "Option A" }, { value: "b" }],
+      initialValue: "a",
+    };
+    assert.deepEqual(getFixCandidates(diag(fix)), [
+      { title: "Pick: Option A", value: "a", isPreferred: false },
+      { title: "Pick: b", value: "b", isPreferred: false },
+    ]);
+  });
+
+  it("batches only automatic function fixes into 'fix all'", () => {
+    const fixes = collectBatchFixes([
+      diag(true),
+      diag({ type: "confirm", message: "x", initialValue: true }),
+      diag({ type: "select", message: "y", options: [{ value: "a" }] }),
+      diag(true),
+      diag(false),
+    ]);
+    // Indices 0 and 3 (the function fixes); prompts and non-fixes are excluded.
+    assert.deepEqual([...fixes.keys()], [0, 3]);
+  });
+});
 
 function* getHovers(doc: TextDocument): Generator<Position> {
   for (const { index } of doc.getText().matchAll(/\^\?/g)) {

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -12,6 +12,7 @@ import {
 import type { TextDocument } from "vscode-languageserver-textdocument";
 
 import service from "./service";
+import { markoCodeActionKinds } from "./service/marko/code-actions";
 import { clearMarkoCacheForFile } from "./utils/file";
 import setupMessages from "./utils/messages";
 import * as documents from "./utils/text-documents";
@@ -49,7 +50,10 @@ connection.onInitialize(async (params) => {
       definitionProvider: true,
       hoverProvider: true,
       renameProvider: true,
-      codeActionProvider: true,
+      codeActionProvider: {
+        resolveProvider: true,
+        codeActionKinds: markoCodeActionKinds,
+      },
       referencesProvider: true,
       documentLinkProvider: { resolveProvider: false },
       colorProvider: true,
@@ -224,6 +228,10 @@ connection.onCodeAction(async (params, cancel) => {
       cancel,
     )) || null
   );
+});
+
+connection.onCodeActionResolve(async (action, cancel) => {
+  return (await service.doCodeActionResolve(action, cancel)) || action;
 });
 
 connection.onDocumentFormatting(async (params, cancel) => {

--- a/packages/language-server/src/service/index.ts
+++ b/packages/language-server/src/service/index.ts
@@ -294,6 +294,17 @@ const service: Plugin = {
 
     return actions;
   },
+  async doCodeActionResolve(action, cancel) {
+    for (const plugin of plugins) {
+      try {
+        const result = await plugin.doCodeActionResolve?.(action, cancel);
+        if (cancel.isCancellationRequested) return;
+        if (result) return result;
+      } catch {
+        // ignore
+      }
+    }
+  },
   async doValidate(doc) {
     const results = await Promise.allSettled(
       plugins.map((plugin) => plugin.doValidate?.(doc)),

--- a/packages/language-server/src/service/marko/code-actions.ts
+++ b/packages/language-server/src/service/marko/code-actions.ts
@@ -1,0 +1,464 @@
+import type { Diagnostic as CompilerDiagnostic } from "@marko/compiler/babel-utils";
+import { Project } from "@marko/language-tools";
+import path from "path";
+import * as prettier from "prettier";
+import * as markoPrettier from "prettier-plugin-marko";
+import {
+  type CodeAction,
+  CodeActionKind,
+  type Diagnostic,
+  type InitializeParams,
+  type Position,
+  type Range,
+  TextEdit,
+} from "vscode-languageserver";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+
+import { getFSPath } from "../../utils/file";
+import * as documents from "../../utils/text-documents";
+import type { Plugin } from "../types";
+import { compilerConfig, getMarkoDiagnostics } from "./validate";
+
+type LocRange = Exclude<CompilerDiagnostic["loc"], undefined | false>;
+
+interface FixCandidate {
+  title: string;
+  /** Value handed to the compiler `applyFixes` map for this fix. */
+  value: unknown;
+  isPreferred: boolean;
+}
+
+const FIX_ACTION_SOURCE = "marko/fix";
+const FIX_ALL_SOURCE = "marko/fix-all";
+
+/** Code action kind for the batched "fix all" source action. */
+export const SOURCE_FIX_ALL_KIND = "source.fixAll.marko";
+
+/** Title shown for the batched "fix all" source action. */
+const FIX_ALL_TITLE = "Fix all auto-fixable Marko issues";
+
+/** Code action kinds this plugin produces, advertised to the client. */
+export const markoCodeActionKinds = [
+  CodeActionKind.QuickFix,
+  SOURCE_FIX_ALL_KIND,
+];
+
+/**
+ * Serializable payload stored on a deferred fix action so its edit can be built
+ * later in `doCodeActionResolve` rather than up front.
+ */
+interface MarkoFixActionData {
+  source: typeof FIX_ACTION_SOURCE;
+  uri: string;
+  version: number;
+  index: number;
+  value: unknown;
+}
+
+/** Serializable payload for a deferred batched "fix all" action. */
+interface MarkoFixAllActionData {
+  source: typeof FIX_ALL_SOURCE;
+  uri: string;
+  version: number;
+}
+
+/**
+ * Whether the client can resolve a code action's `edit` lazily. When it can, we
+ * defer the (relatively expensive) reprint + format until the user actually
+ * engages a fix instead of building an edit for every offered action up front.
+ */
+let resolveSupported = false;
+
+export function initialize(params: InitializeParams): void {
+  resolveSupported = Boolean(
+    params.capabilities.textDocument?.codeAction?.resolveSupport?.properties.includes(
+      "edit",
+    ),
+  );
+}
+
+/**
+ * Surfaces the Marko compiler's diagnostic `fix`es (in place AST edits suggested
+ * by compiler plugins) as in editor code actions: a quick fix per fixable
+ * diagnostic in range, plus a batched "fix all" source action.
+ *
+ * A fix mutates the AST during compilation, so it can't be serialized into a
+ * text edit directly. Instead we re-run the compiler asking it to apply the
+ * relevant fix(es) -- via the `applyFixes` config keyed by diagnostic index --
+ * reprint the result in `migrate` mode, format it with prettier, and diff it
+ * against the original document to produce a minimal text edit.
+ *
+ * A fix is either an automatic function fix or an interactive `confirm`/`select`
+ * prompt; see `getFixCandidates` and `collectBatchFixes` for how each is
+ * surfaced.
+ */
+export const doCodeActions: Plugin["doCodeActions"] = async (
+  doc,
+  params,
+  cancel,
+) => {
+  // Gate the per-diagnostic quick fixes and the batched "fix all" source action
+  // independently so a `source.fixAll`-only request (e.g. fix-on-save) returns
+  // just the batch, and a `quickfix`-only request returns just the quick fixes.
+  const { only } = params.context;
+  const wantsQuickFix = isKindRequested(only, CodeActionKind.QuickFix);
+  const wantsFixAll = isKindRequested(only, SOURCE_FIX_ALL_KIND);
+  if (!wantsQuickFix && !wantsFixAll) return;
+
+  // Reuse the diagnostics compile from `doValidate` (cached per document
+  // version) so requesting code actions doesn't compile the document again.
+  const { diagnostics } = getMarkoDiagnostics(doc);
+  if (!diagnostics?.length) return;
+
+  const filename = getFSPath(doc);
+  const compiler = Project.getCompiler(filename && path.dirname(filename));
+  const originalText = doc.getText();
+  const actions: CodeAction[] = [];
+
+  if (wantsQuickFix) {
+    // The index of a diagnostic is the key used to apply its fix, so iterate by
+    // index. The diagnostics here line up with what `doValidate` reports because
+    // both use the same `compilerConfig`.
+    for (let index = 0; index < diagnostics.length; index++) {
+      const diag = diagnostics[index];
+      if (!diag.fix || !diag.loc) continue;
+
+      const range = locToRange(diag.loc);
+      if (!rangesOverlap(range, params.range)) continue;
+
+      const relatedDiagnostics = findRelatedDiagnostics(
+        params.context.diagnostics,
+        range,
+        diag.label,
+      );
+
+      for (const candidate of getFixCandidates(diag)) {
+        if (cancel.isCancellationRequested) return;
+
+        const action: CodeAction = {
+          title: candidate.title,
+          kind: CodeActionKind.QuickFix,
+          diagnostics: relatedDiagnostics.length
+            ? relatedDiagnostics
+            : undefined,
+          isPreferred: candidate.isPreferred || undefined,
+        };
+
+        if (resolveSupported) {
+          // Defer the reprint + format until the action is resolved.
+          action.data = {
+            source: FIX_ACTION_SOURCE,
+            uri: doc.uri,
+            version: doc.version,
+            index,
+            value: candidate.value,
+          } satisfies MarkoFixActionData;
+        } else {
+          const edit = await buildFixEdit(
+            doc,
+            compiler,
+            filename,
+            originalText,
+            new Map([[index, candidate.value]]),
+          );
+          if (cancel.isCancellationRequested) return;
+          if (!edit) continue;
+          action.edit = { changes: { [doc.uri]: [edit] } };
+        }
+
+        actions.push(action);
+      }
+    }
+  }
+
+  if (wantsFixAll) {
+    // A single "fix all" applies every auto-fixable diagnostic in one compile
+    // pass (the `applyFixes` map takes many entries). This is both faster than
+    // and more correct than chaining the individual fixes, whose edits are each
+    // computed against the original text and would shift one another's ranges.
+    const fixes = collectBatchFixes(diagnostics);
+    if (fixes.size) {
+      const action: CodeAction = {
+        title: FIX_ALL_TITLE,
+        kind: SOURCE_FIX_ALL_KIND,
+      };
+
+      if (resolveSupported) {
+        action.data = {
+          source: FIX_ALL_SOURCE,
+          uri: doc.uri,
+          version: doc.version,
+        } satisfies MarkoFixAllActionData;
+        actions.push(action);
+      } else {
+        const edit = await buildFixEdit(
+          doc,
+          compiler,
+          filename,
+          originalText,
+          fixes,
+        );
+        if (cancel.isCancellationRequested) return;
+        if (edit) {
+          action.edit = { changes: { [doc.uri]: [edit] } };
+          actions.push(action);
+        }
+      }
+    }
+  }
+
+  return actions.length ? actions : undefined;
+};
+
+/**
+ * Resolves a deferred fix (or fix-all) action by re-running the compiler to
+ * apply the fix(es) and attaching the resulting text edit.
+ */
+export const doCodeActionResolve: NonNullable<
+  Plugin["doCodeActionResolve"]
+> = async (action, cancel) => {
+  const data = action.data as
+    | MarkoFixActionData
+    | MarkoFixAllActionData
+    | undefined;
+  if (data?.source !== FIX_ACTION_SOURCE && data?.source !== FIX_ALL_SOURCE) {
+    return; // not one of ours
+  }
+
+  const doc = documents.get(data.uri);
+  // The action was created for a specific document version; if the document has
+  // since changed we can no longer trust the diagnostic indices, so leave it be.
+  if (!doc || doc.version !== data.version) return action;
+
+  let fixes: Map<number, unknown>;
+  if (data.source === FIX_ACTION_SOURCE) {
+    fixes = new Map([[data.index, data.value]]);
+  } else {
+    const { diagnostics } = getMarkoDiagnostics(doc);
+    if (!diagnostics) return action;
+    fixes = collectBatchFixes(diagnostics);
+  }
+  if (!fixes.size) return action;
+
+  const filename = getFSPath(doc);
+  const compiler = Project.getCompiler(filename && path.dirname(filename));
+  const edit = await buildFixEdit(
+    doc,
+    compiler,
+    filename,
+    doc.getText(),
+    fixes,
+  );
+  if (cancel.isCancellationRequested) return;
+  if (edit) action.edit = { changes: { [doc.uri]: [edit] } };
+
+  return action;
+};
+
+/**
+ * Maps a diagnostic's fix to the quick fix action(s) to offer for it.
+ *
+ * The compiler's diagnostics API models a `fix` as one of three things:
+ * - `true`: an automatic function fix (applied by the compiler in `migrate`
+ *   output without asking) -> a single, preferred quick fix.
+ * - a `confirm` prompt (a yes/no decision) -> a single quick fix whose
+ *   invocation answers "yes" (`apply(true)`).
+ * - a `select` prompt (pick one of N options) -> one quick fix per option
+ *   (`apply(option.value)`).
+ *
+ * `confirm`/`select` are interactive prompts, so they are never marked preferred
+ * -- the user must consciously choose, rather than have "Auto Fix" answer for
+ * them -- and they are excluded from the batched "fix all".
+ */
+export function getFixCandidates(diag: CompilerDiagnostic): FixCandidate[] {
+  const { fix } = diag;
+
+  // An automatic function fix.
+  if (fix === true) {
+    return [{ title: diag.label, value: undefined, isPreferred: true }];
+  }
+
+  if (typeof fix === "object") {
+    switch (fix.type) {
+      // A yes/no prompt; invoking the action answers "yes".
+      case "confirm":
+        return [{ title: fix.message, value: true, isPreferred: false }];
+      // A pick-one prompt; offer one action per option.
+      case "select":
+        return fix.options.map((option) => ({
+          title: `${fix.message}: ${option.label ?? option.value}`,
+          value: option.value,
+          isPreferred: false,
+        }));
+    }
+  }
+
+  return [];
+}
+
+/**
+ * Re-compiles the document applying the given `fixes` (one entry for a single
+ * quick fix, many for "fix all") in a single pass and returns a minimal text
+ * edit representing the change.
+ */
+async function buildFixEdit(
+  doc: TextDocument,
+  compiler: ReturnType<typeof Project.getCompiler>,
+  filename: string | undefined,
+  originalText: string,
+  fixes: Map<number, unknown>,
+): Promise<TextEdit | undefined> {
+  let fixedCode: string | undefined;
+  try {
+    ({ code: fixedCode } = compiler.compileSync(
+      originalText,
+      filename || "untitled.marko",
+      {
+        ...compilerConfig,
+        code: true,
+        applyFixes: fixes,
+      },
+    ));
+  } catch {
+    // Applying the fix produced a state the compiler could not print.
+    return;
+  }
+
+  if (!fixedCode) return;
+
+  const formatted = await formatMarko(fixedCode, filename);
+  return getMinimalEdit(doc, originalText, formatted ?? fixedCode);
+}
+
+/**
+ * Builds the `applyFixes` map for a batched "fix all" from the diagnostics whose
+ * fix is applied automatically -- function fixes (`fix === true`), the same set
+ * the compiler applies in `migrate` output without prompting.
+ *
+ * `confirm`/`select` fixes are interactive prompts: the compiler only applies
+ * them when given an explicit answer (with no answer their `apply` is a no-op),
+ * so they're deliberately excluded here and instead offered as individual quick
+ * fixes where the user makes the choice.
+ */
+export function collectBatchFixes(
+  diagnostics: CompilerDiagnostic[],
+): Map<number, unknown> {
+  const fixes = new Map<number, unknown>();
+  diagnostics.forEach((diag, index) => {
+    if (diag.fix === true) fixes.set(index, undefined);
+  });
+  return fixes;
+}
+
+/**
+ * Formats reprinted Marko source with prettier (reusing the same plugin and
+ * resolved config as the formatter) so applying a fix doesn't reflow the rest of
+ * the document. Falls back to the unformatted source if prettier throws.
+ */
+async function formatMarko(
+  code: string,
+  filepath: string | undefined,
+): Promise<string | undefined> {
+  try {
+    return await prettier.format(code, {
+      parser: "marko",
+      filepath,
+      plugins: [markoPrettier],
+      ...(filepath
+        ? await prettier
+            .resolveConfig(filepath, { editorconfig: true })
+            .catch(() => null)
+        : null),
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Produces a single text edit covering only the region that differs between the
+ * original and updated text by trimming the common prefix and suffix.
+ */
+function getMinimalEdit(
+  doc: TextDocument,
+  oldText: string,
+  newText: string,
+): TextEdit | undefined {
+  if (oldText === newText) return undefined;
+
+  const maxStart = Math.min(oldText.length, newText.length);
+  let start = 0;
+  while (
+    start < maxStart &&
+    oldText.charCodeAt(start) === newText.charCodeAt(start)
+  ) {
+    start++;
+  }
+
+  let oldEnd = oldText.length;
+  let newEnd = newText.length;
+  while (
+    oldEnd > start &&
+    newEnd > start &&
+    oldText.charCodeAt(oldEnd - 1) === newText.charCodeAt(newEnd - 1)
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  return TextEdit.replace(
+    { start: doc.positionAt(start), end: doc.positionAt(oldEnd) },
+    newText.slice(start, newEnd),
+  );
+}
+
+/**
+ * Finds the published diagnostics that this fix resolves so the editor can
+ * associate the quick fix with the squiggle it appears on.
+ */
+function findRelatedDiagnostics(
+  contextDiagnostics: Diagnostic[],
+  range: Range,
+  label: string,
+): Diagnostic[] {
+  return contextDiagnostics.filter(
+    (diagnostic) =>
+      diagnostic.source === "marko" &&
+      diagnostic.message === label &&
+      rangesEqual(diagnostic.range, range),
+  );
+}
+
+function locToRange(loc: LocRange): Range {
+  return {
+    start: { line: loc.start.line - 1, character: loc.start.column },
+    end: { line: loc.end.line - 1, character: loc.end.column },
+  };
+}
+
+function isKindRequested(only: string[] | undefined, kind: string): boolean {
+  return (
+    !only ||
+    only.some(
+      (requested) => kind === requested || kind.startsWith(`${requested}.`),
+    )
+  );
+}
+
+function rangesOverlap(a: Range, b: Range): boolean {
+  return (
+    comparePositions(a.start, b.end) <= 0 &&
+    comparePositions(b.start, a.end) <= 0
+  );
+}
+
+function rangesEqual(a: Range, b: Range): boolean {
+  return (
+    comparePositions(a.start, b.start) === 0 &&
+    comparePositions(a.end, b.end) === 0
+  );
+}
+
+function comparePositions(a: Position, b: Position): number {
+  return a.line - b.line || a.character - b.character;
+}

--- a/packages/language-server/src/service/marko/index.ts
+++ b/packages/language-server/src/service/marko/index.ts
@@ -1,5 +1,6 @@
 import * as documents from "../../utils/text-documents";
 import type { Plugin } from "../types";
+import { doCodeActionResolve, doCodeActions, initialize } from "./code-actions";
 import { doComplete } from "./complete";
 import { findDefinition } from "./definition";
 import { findDocumentLinks } from "./document-links";
@@ -9,9 +10,12 @@ import { doHover } from "./hover";
 import { doValidate } from "./validate";
 
 export default {
+  initialize,
   doComplete,
   doValidate,
   doHover,
+  doCodeActions,
+  doCodeActionResolve,
   findDefinition,
   findDocumentLinks,
   findDocumentSymbols,

--- a/packages/language-server/src/service/marko/validate.ts
+++ b/packages/language-server/src/service/marko/validate.ts
@@ -1,15 +1,46 @@
 import type { Config } from "@marko/compiler";
-import { DiagnosticType } from "@marko/compiler/babel-utils";
+import {
+  type Diagnostic as CompilerDiagnostic,
+  DiagnosticType,
+} from "@marko/compiler/babel-utils";
 import { Project } from "@marko/language-tools";
 import path from "path";
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
+import type { TextDocument } from "vscode-languageserver-textdocument";
 
 import { getFSPath } from "../../utils/file";
 import type { Plugin } from "../types";
 
+/**
+ * The result of compiling a document for diagnostics: either the compiler's
+ * diagnostics or the error thrown while trying to compile it.
+ */
+export type MarkoDiagnosticsResult =
+  | { diagnostics: CompilerDiagnostic[]; error?: undefined }
+  | { diagnostics?: undefined; error: unknown };
+
+/**
+ * Caches the compiler diagnostics per document version so that `doValidate` and
+ * the code action provider can share a single compile instead of compiling the
+ * same document twice.
+ */
+const diagnosticsCache = new WeakMap<
+  TextDocument,
+  { version: number; result: MarkoDiagnosticsResult }
+>();
+
 const markoErrorRegExp =
   /^(.+?)\.marko(?:\((\d+)(?:\s*,\s*(\d+))?\))?: (.*)$/gm;
-const compilerConfig: Config = {
+
+/**
+ * Shared compiler config used to surface diagnostics. Runs through the
+ * `migrate` output (the latest stage diagnostic fixes can be registered in)
+ * with error recovery so that all recoverable diagnostics are returned on
+ * `meta.diagnostics` instead of being thrown. The code action provider reuses
+ * this same config so the diagnostics (and their indices) line up exactly with
+ * what is reported here.
+ */
+export const compilerConfig: Config = {
   code: false,
   output: "migrate",
   sourceMaps: false,
@@ -28,60 +59,78 @@ const compilerConfig: Config = {
   },
 };
 
-export const doValidate: Plugin["doValidate"] = (doc) => {
-  const filename = getFSPath(doc);
-  const diagnostics: Diagnostic[] = [];
+/**
+ * Compiles the document for diagnostics, caching the result per document
+ * version. Both `doValidate` and the code action provider call this so the
+ * document is only compiled once per change.
+ */
+export function getMarkoDiagnostics(doc: TextDocument): MarkoDiagnosticsResult {
+  const cached = diagnosticsCache.get(doc);
+  if (cached && cached.version === doc.version) return cached.result;
 
+  const filename = getFSPath(doc);
+  let result: MarkoDiagnosticsResult;
   try {
     const { meta } = Project.getCompiler(
       filename && path.dirname(filename),
     ).compileSync(doc.getText(), filename || "untitled.marko", compilerConfig);
+    result = { diagnostics: meta.diagnostics };
+  } catch (error) {
+    result = { error };
+  }
 
-    if (meta.diagnostics) {
-      for (const diag of meta.diagnostics) {
-        const range = diag.loc
-          ? {
-              start: {
-                line: diag.loc.start.line - 1,
-                character: diag.loc.start.column,
-              },
-              end: {
-                line: diag.loc.end.line - 1,
-                character: diag.loc.end.column,
-              },
-            }
-          : {
-              start: { line: 0, character: 0 },
-              end: { line: 0, character: 0 },
-            };
+  diagnosticsCache.set(doc, { version: doc.version, result });
+  return result;
+}
 
-        let severity: DiagnosticSeverity | undefined;
+export const doValidate: Plugin["doValidate"] = (doc) => {
+  const diagnostics: Diagnostic[] = [];
+  const result = getMarkoDiagnostics(doc);
 
-        switch (diag.type) {
-          case DiagnosticType.Warning:
-          case DiagnosticType.Deprecation:
-            severity = DiagnosticSeverity.Warning;
-            break;
-          case DiagnosticType.Suggestion:
-            severity = DiagnosticSeverity.Hint;
-            break;
-          default:
-            severity = DiagnosticSeverity.Error;
-            break;
-        }
+  if (result.diagnostics) {
+    for (const diag of result.diagnostics) {
+      const range = diag.loc
+        ? {
+            start: {
+              line: diag.loc.start.line - 1,
+              character: diag.loc.start.column,
+            },
+            end: {
+              line: diag.loc.end.line - 1,
+              character: diag.loc.end.column,
+            },
+          }
+        : {
+            start: { line: 0, character: 0 },
+            end: { line: 0, character: 0 },
+          };
 
-        diagnostics.push({
-          range,
-          source: "marko",
-          code: undefined,
-          tags: undefined,
-          severity,
-          message: diag.label,
-        });
+      let severity: DiagnosticSeverity | undefined;
+
+      switch (diag.type) {
+        case DiagnosticType.Warning:
+        case DiagnosticType.Deprecation:
+          severity = DiagnosticSeverity.Warning;
+          break;
+        case DiagnosticType.Suggestion:
+          severity = DiagnosticSeverity.Hint;
+          break;
+        default:
+          severity = DiagnosticSeverity.Error;
+          break;
       }
+
+      diagnostics.push({
+        range,
+        source: "marko",
+        code: undefined,
+        tags: undefined,
+        severity,
+        message: diag.label,
+      });
     }
-  } catch (err) {
-    addDiagnosticsForError(err, diagnostics);
+  } else {
+    addDiagnosticsForError(result.error, diagnostics);
   }
 
   return diagnostics;

--- a/packages/language-server/src/service/types.ts
+++ b/packages/language-server/src/service/types.ts
@@ -51,6 +51,10 @@ export type Plugin = {
   doHover: Handler<HoverParams, Hover>;
   doRename: Handler<RenameParams, WorkspaceEdit>;
   doCodeActions: Handler<CodeActionParams, (Command | CodeAction)[]>;
+  doCodeActionResolve: (
+    action: CodeAction,
+    token: CancellationToken,
+  ) => Result<CodeAction>;
   findDefinition: Handler<
     DefinitionParams,
     Location | LocationLink | (Location | LocationLink)[]


### PR DESCRIPTION
## Summary

Surface the Marko compiler's diagnostic `fix`es — in-place AST edits suggested by compiler plugins via the diagnostics API (e.g. the `data` → `input` migration) — as in-editor code actions:

- **Quick fixes** — one per fixable diagnostic in range.
- **Fix all** — a batched `source.fixAll.marko` source action that applies every auto-fixable issue in a single compile pass, so it plugs into VS Code's **Fix All** command and `editor.codeActionsOnSave`.

A fix mutates the AST during compilation, so it can't be serialized to a text edit directly. Applying one re-runs the compiler asking it to apply the relevant fix(es) — via the `applyFixes` config keyed by diagnostic index — reprints the result in `migrate` output, formats it with prettier, and diffs it against the document to produce a **minimal** text edit (the rest of the file is left untouched).

### Fix kinds & the "prompts" feature

The diagnostics API models a `fix` three ways. The compiler only auto-applies the first; the others are interactive prompts that no-op without an explicit answer, so they're surfaced as explicit choices:

| `fix` | Surfaced as |
| --- | --- |
| function (automatic) | one preferred quick fix; included in **fix all** |
| `confirm` (yes/no prompt) | one non-preferred action that answers "yes" |
| `select` (pick-one prompt) | one non-preferred action per option |

`confirm`/`select` are never auto-applied or marked preferred (so "Auto Fix" can't silently answer for you) and are excluded from "fix all", matching the compiler's own `migrate` behavior.

## Notes

- **Lazy resolve.** Edits are computed on `codeAction/resolve` (gated on the client advertising `resolveSupport` for `edit`), so nothing extra is compiled until a fix is actually used; clients without resolve support get the edit eagerly.
- **Shared compile.** The diagnostics compile is cached per document version and shared with `doValidate`, so requesting code actions reuses validation's compile instead of recompiling the template.
- **Capability & gating.** The server advertises `codeActionKinds: ["quickfix", "source.fixAll.marko"]` and gates `context.only` so a `source.fixAll` request returns only the batch and a `quickfix` request returns only the per-diagnostic fixes.

## Test plan

- Fixtures `code-action/data-deprecation` and `code-action/fix-all` snapshot the offered quick fixes and the batched result, exercised through the lazy resolve path.
- Unit tests cover the `context.only` kind filtering and the function/`confirm`/`select` prompt mapping.
- `npm test` (build + 142 snapshot/unit tests) passes; `eslint`, `prettier --check`, and `cspell` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MoPRewDgoKEigor9yvxCg