### PR TITLE
feat: clean identifiers for Marko component auto-imports

### DIFF
--- a/.changeset/component-auto-import-names.md
+++ b/.changeset/component-auto-import-names.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-tools": patch
+---
+
+Name the default export of auto-discoverable Marko components (files under a `components`/`tags` directory) after the tag, so auto-imports read `import MyButton from "..."` instead of TypeScript's file-derived `MyButtonMarko` (and `Foo` instead of `index` for `foo/index.marko`).

--- a/packages/language-server/src/__tests__/component-auto-import.test.ts
+++ b/packages/language-server/src/__tests__/component-auto-import.test.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+
+import { Project } from "@marko/language-tools";
+import path from "path";
+import { CancellationToken } from "vscode-languageserver";
+import { URI } from "vscode-uri";
+
+import MarkoLanguageService, { documents } from "../service";
+import * as workspace from "../utils/workspace";
+
+Project.setDefaultTypePaths({
+  internalTypesFile:
+    require.resolve("@marko/language-tools/marko.internal.d.ts"),
+  markoTypesFile: require.resolve("marko/index.d.ts"),
+});
+
+// `doComplete` reads editor config through the workspace connection; a stub that
+// resolves every section to `{}` keeps the default preferences (auto-imports on).
+workspace.setup({
+  onDidChangeConfiguration() {},
+  workspace: { getConfiguration: async () => ({}) },
+} as never);
+
+// A fresh virtual directory per call avoids stale parse/project caches; it sits
+// under `fixtures` so taglib/tsconfig resolution works, but nothing is written
+// to disk.
+let runId = 0;
+function openAll(components: Record<string, string>) {
+  const dir = path.join(
+    __dirname,
+    "fixtures",
+    "script",
+    `__component-${runId++}`,
+  );
+  const uris: Record<string, string> = {};
+  const opened: string[] = [];
+  for (const [rel, text] of Object.entries(components)) {
+    const uri = URI.file(path.join(dir, rel)).toString();
+    documents.doOpen({
+      textDocument: { uri, languageId: "marko", version: 1, text },
+    });
+    uris[rel] = uri;
+    opened.push(uri);
+  }
+  return {
+    uris,
+    dispose: () =>
+      opened.forEach((uri) => documents.doClose({ textDocument: { uri } })),
+  };
+}
+
+// Returns the default-export-related lines of a component's extracted module.
+async function defaultExport(filename: string, text = "<div/>\n") {
+  const { uris, dispose } = openAll({ [filename]: text });
+  try {
+    const out = (await MarkoLanguageService.commands["$/showScriptOutput"](
+      uris[filename],
+    )) as { content: string } | undefined;
+    return (out?.content ?? "")
+      .split("\n")
+      .filter((line) => /export default|= new \(/.test(line))
+      .join("\n");
+  } finally {
+    dispose();
+  }
+}
+
+describe("marko component default export naming", () => {
+  it("names the export for a discoverable component file", async () => {
+    const out = await defaultExport("components/my-component.marko");
+    assert.match(out, /const MyComponent = new \(/);
+    assert.match(out, /export default MyComponent;/);
+  });
+
+  it("uses the directory name for index / self-named tag files", async () => {
+    assert.match(
+      await defaultExport("components/data-table/index.marko"),
+      /const DataTable = new \(/,
+    );
+    assert.match(
+      await defaultExport("tags/widget/widget.marko"),
+      /const Widget = new \(/,
+    );
+  });
+
+  it("leaves non-discoverable files as an anonymous export", async () => {
+    // Not under a `components`/`tags` directory.
+    assert.match(
+      await defaultExport("src/Modal.marko"),
+      /export default new \(/,
+    );
+    // A nested file that isn't the index or the self-named tag file.
+    const nested = await defaultExport("components/foo/bar.marko");
+    assert.match(nested, /export default new \(/);
+    assert.doesNotMatch(nested, /const \w+ = new \(/);
+  });
+
+  it("falls back to an anonymous export when the name appears in the source", async () => {
+    const out = await defaultExport(
+      "components/widget.marko",
+      "static const Widget = 1\n<div/>\n",
+    );
+    assert.match(out, /export default new \(/);
+    assert.doesNotMatch(out, /const Widget = new \(/);
+  });
+
+  it("skips naming when the tag name is not a valid identifier", async () => {
+    assert.match(
+      await defaultExport("components/3d-view.marko"),
+      /export default new \(/,
+    );
+  });
+
+  it("offers a clean `import MyComponent` auto-import", async () => {
+    const { uris, dispose } = openAll({
+      "components/my-component.marko": "<div/>\n",
+      "index.marko": "static const a = MyComponent\n",
+    });
+    try {
+      const doc = documents.get(uris["index.marko"])!;
+      const text = "static const a = MyComponent\n";
+      const result = await MarkoLanguageService.doComplete(
+        doc,
+        {
+          textDocument: { uri: uris["index.marko"] },
+          position: doc.positionAt(text.indexOf("MyComponent") + 11),
+          context: { triggerKind: 1 },
+        } as never,
+        CancellationToken.None,
+      );
+      const items = Array.isArray(result) ? result : (result?.items ?? []);
+      const item = items.find(
+        (i) =>
+          i.label === "MyComponent" &&
+          /\.marko$/.test(
+            (i.data as { originalSource?: string })?.originalSource ?? "",
+          ),
+      );
+      assert.ok(item, "expected a MyComponent auto-import");
+      const resolved = await MarkoLanguageService.doCompletionResolve(
+        JSON.parse(JSON.stringify(item)),
+        CancellationToken.None,
+      );
+      assert.equal(
+        (resolved?.additionalTextEdits ?? [])
+          .map((e) => e.newText.trim())
+          .join(""),
+        'import MyComponent from "./components/my-component.marko";',
+      );
+    } finally {
+      dispose();
+    }
+  });
+});

--- a/packages/language-server/src/__tests__/fixtures/script/attr-class-id-shorthands/__snapshots__/attr-class-id-shorthands.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-class-id-shorthands/__snapshots__/attr-class-id-shorthands.expected/components/test-tag.ts
@@ -19,7 +19,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -54,3 +54,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tag-target-property/__snapshots__/attr-tag-target-property.expected/components/test-tag/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tag-target-property/__snapshots__/attr-tag-target-property.expected/components/test-tag/index.ts
@@ -21,7 +21,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -56,3 +56,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-dynamic-for-typed/__snapshots__/attr-tags-dynamic-for-typed.expected/tags/my-menu/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-dynamic-for-typed/__snapshots__/attr-tags-dynamic-for-typed.expected/tags/my-menu/index.ts
@@ -33,7 +33,7 @@ export interface Input {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const MyMenu = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -68,3 +68,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default MyMenu;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/__snapshots__/attr-tags-for-narrowing.expected/components/list.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-for-narrowing/__snapshots__/attr-tags-for-narrowing.expected/components/list.ts
@@ -20,7 +20,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const List = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -55,3 +55,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default List;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-generic/__snapshots__/attr-tags-generic.expected/tags/foo/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-generic/__snapshots__/attr-tags-generic.expected/tags/foo/index.ts
@@ -18,7 +18,7 @@ export interface Input<T> {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Foo = new (class Template extends Marko._.Template<{
   render<T>(
     input: Marko.TemplateInput<Input<T>>,
     stream?: {
@@ -61,3 +61,4 @@ export default new (class Template extends Marko._.Template<{
           Marko._.Relate<__marko_internal_input, Marko.Directives & Input<T>>,
       ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Foo;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-nested-dynamic-for-typed/__snapshots__/attr-tags-nested-dynamic-for-typed.expected/tags/my-layout/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-nested-dynamic-for-typed/__snapshots__/attr-tags-nested-dynamic-for-typed.expected/tags/my-layout/index.ts
@@ -43,7 +43,7 @@ export interface Input {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const MyLayout = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -78,3 +78,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default MyLayout;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-nested-type/__snapshots__/attr-tags-nested-type.expected/components/list.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-nested-type/__snapshots__/attr-tags-nested-type.expected/components/list.ts
@@ -22,7 +22,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const List = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -57,3 +57,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default List;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-params-js/__snapshots__/attr-tags-params-js.expected/components/child.js
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-params-js/__snapshots__/attr-tags-params-js.expected/components/child.js
@@ -28,7 +28,8 @@ export class Component extends Marko.Component {}
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new /**
+const Child = new /**
  * @extends { Marko._.Template<{              render(         input: Marko.TemplateInput<Input>,         stream?: {           write: (chunk: string) => void;           end: (chunk?: string) => void;         },       ): Marko.Out<Component>;               render(         input: Marko.TemplateInput<Input>,         cb?: (           err: Error | null,           result: Marko.RenderResult<Component>,         ) => void,       ): Marko.Out<Component>;               renderSync(         input: Marko.TemplateInput<Input>,       ): Marko.RenderResult<Component>;               renderToString(input: Marko.TemplateInput<Input>): string;               stream(         input: Marko.TemplateInput<Input>,       ): ReadableStream<string> & NodeJS.ReadableStream;               mount(         input: Marko.TemplateInput<Input>,         reference: Node,         position?: "afterbegin" | "afterend" | "beforebegin" | "beforeend",       ): Marko.MountedTemplate<typeof input>;          api: typeof __marko_internal_api,   _(): () => <__marko_internal_input extends unknown>(input: Marko.Directives & Input & Marko._.Relate<__marko_internal_input, Marko.Directives & Input>) => (Marko._.ReturnWithScope<__marko_internal_input, void>); }>}
  */
 (class Template extends Marko._.Template {})();
+export default Child;

--- a/packages/language-server/src/__tests__/fixtures/script/attr-tags-params/__snapshots__/attr-tags-params.expected/components/child.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/attr-tags-params/__snapshots__/attr-tags-params.expected/components/child.ts
@@ -21,7 +21,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Child = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -56,3 +56,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Child;

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-missing-impl/__snapshots__/bound-attr-missing-impl.expected/tags/child.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-missing-impl/__snapshots__/bound-attr-missing-impl.expected/tags/child.ts
@@ -14,7 +14,7 @@ export interface Input {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Child = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -49,3 +49,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Child;

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-modifier-dynamic-member/__snapshots__/bound-attr-modifier-dynamic-member.expected/tags/child.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-modifier-dynamic-member/__snapshots__/bound-attr-modifier-dynamic-member.expected/tags/child.ts
@@ -14,7 +14,7 @@ export interface Input {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Child = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -49,3 +49,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Child;

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-modifier-ident/__snapshots__/bound-attr-modifier-ident.expected/tags/child.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-modifier-ident/__snapshots__/bound-attr-modifier-ident.expected/tags/child.ts
@@ -14,7 +14,7 @@ export interface Input {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Child = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -49,3 +49,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Child;

--- a/packages/language-server/src/__tests__/fixtures/script/bound-attr-modifier-literal-member/__snapshots__/bound-attr-modifier-literal-member.expected/tags/child.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/bound-attr-modifier-literal-member/__snapshots__/bound-attr-modifier-literal-member.expected/tags/child.ts
@@ -14,7 +14,7 @@ export interface Input {
 })();
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Child = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -49,3 +49,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Child;

--- a/packages/language-server/src/__tests__/fixtures/script/class-api-basic/__snapshots__/class-api-basic.expected/components/fancy-button/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/class-api-basic/__snapshots__/class-api-basic.expected/components/fancy-button/index.ts
@@ -26,7 +26,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const FancyButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -61,3 +61,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default FancyButton;

--- a/packages/language-server/src/__tests__/fixtures/script/class-api-event-binding/__snapshots__/class-api-event-binding.expected/components/fancy-button/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/class-api-event-binding/__snapshots__/class-api-event-binding.expected/components/fancy-button/index.ts
@@ -18,7 +18,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const FancyButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -53,3 +53,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default FancyButton;

--- a/packages/language-server/src/__tests__/fixtures/script/custom-tag-args/__snapshots__/custom-tag-args.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/custom-tag-args/__snapshots__/custom-tag-args.expected/components/test-tag.ts
@@ -19,7 +19,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -54,3 +54,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/__snapshots__/for-tag-attr-tags.expected/components/my-table.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-attr-tags/__snapshots__/for-tag-attr-tags.expected/components/my-table.ts
@@ -20,7 +20,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const MyTable = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -55,3 +55,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default MyTable;

--- a/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/components/my-select.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/for-tag-input/__snapshots__/for-tag-input.expected/components/my-select.ts
@@ -21,7 +21,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const MySelect = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -56,3 +56,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default MySelect;

--- a/packages/language-server/src/__tests__/fixtures/script/invalid-attrs/__snapshots__/invalid-attrs.expected/components/fancy-button/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/invalid-attrs/__snapshots__/invalid-attrs.expected/components/fancy-button/index.ts
@@ -26,7 +26,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const FancyButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -61,3 +61,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default FancyButton;

--- a/packages/language-server/src/__tests__/fixtures/script/prefer-local-identifier-tag-name/__snapshots__/prefer-local-identifier-tag-name.expected/components/TestTagA.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/prefer-local-identifier-tag-name/__snapshots__/prefer-local-identifier-tag-name.expected/components/TestTagA.ts
@@ -19,7 +19,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTagA = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -54,3 +54,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTagA;

--- a/packages/language-server/src/__tests__/fixtures/script/prefer-local-identifier-tag-name/__snapshots__/prefer-local-identifier-tag-name.expected/components/TestTagB.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/prefer-local-identifier-tag-name/__snapshots__/prefer-local-identifier-tag-name.expected/components/TestTagB.ts
@@ -19,7 +19,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTagB = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -54,3 +54,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTagB;

--- a/packages/language-server/src/__tests__/fixtures/script/recursive-input-provided/__snapshots__/recursive-input-provided.expected/components/comments.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/recursive-input-provided/__snapshots__/recursive-input-provided.expected/components/comments.ts
@@ -22,7 +22,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Comments = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -57,4 +57,5 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Comments;
 // Empty

--- a/packages/language-server/src/__tests__/fixtures/script/recursive-input-scope-hoist/__snapshots__/recursive-input-scope-hoist.expected/components/comments.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/recursive-input-scope-hoist/__snapshots__/recursive-input-scope-hoist.expected/components/comments.ts
@@ -23,7 +23,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Comments = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -58,4 +58,5 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Comments;
 // Empty

--- a/packages/language-server/src/__tests__/fixtures/script/render-body-basic/__snapshots__/render-body-basic.expected/components/my-tag/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/render-body-basic/__snapshots__/render-body-basic.expected/components/my-tag/index.ts
@@ -20,7 +20,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const MyTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -55,3 +55,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default MyTag;

--- a/packages/language-server/src/__tests__/fixtures/script/return-as-type/__snapshots__/return-as-type.expected/tags/oneOrTwo.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/return-as-type/__snapshots__/return-as-type.expected/tags/oneOrTwo.ts
@@ -38,7 +38,7 @@ function __marko_internal_template(this: void) {
 }
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const OneOrTwo = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -76,4 +76,5 @@ export default new (class Template extends Marko._.Template<{
     typeof __marko_internal_template extends () => infer Return ? Return : never
   >;
 }> {})();
+export default OneOrTwo;
 // ^?

--- a/packages/language-server/src/__tests__/fixtures/script/return-tag-nested/__snapshots__/return-tag-nested.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/return-tag-nested/__snapshots__/return-tag-nested.expected/components/test-tag.ts
@@ -20,7 +20,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -55,3 +55,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/fancy-button/index.d.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/fancy-button/index.d.ts
@@ -17,7 +17,7 @@ export interface Component extends Marko._.ResolveComponent<
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const FancyButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -52,3 +52,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default FancyButton;

--- a/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/fancy-button/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/fancy-button/index.ts
@@ -17,7 +17,7 @@ export interface Component extends Marko._.ResolveComponent<
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const FancyButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -52,3 +52,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default FancyButton;

--- a/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/regular-button/index.d.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/regular-button/index.d.ts
@@ -17,7 +17,7 @@ export interface Component extends Marko._.ResolveComponent<
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const RegularButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -52,3 +52,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default RegularButton;

--- a/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/regular-button/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/split-component-d-ts/__snapshots__/split-component-d-ts.expected/components/regular-button/index.ts
@@ -17,7 +17,7 @@ export interface Component extends Marko._.ResolveComponent<
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const RegularButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -52,3 +52,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default RegularButton;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-param-mutation/__snapshots__/tag-param-mutation.expected/components/test-tag.ts
@@ -20,7 +20,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -55,3 +55,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-params-basic/__snapshots__/tag-params-basic.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-params-basic/__snapshots__/tag-params-basic.expected/components/test-tag.ts
@@ -24,7 +24,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -59,3 +59,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-params-with-generics/__snapshots__/tag-params-with-generics.expected/components/loader.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-params-with-generics/__snapshots__/tag-params-with-generics.expected/components/loader.ts
@@ -22,7 +22,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const Loader = new (class Template extends Marko._.Template<{
   render<TData = string>(
     input: Marko.TemplateInput<Input<TData>>,
     stream?: {
@@ -76,3 +76,4 @@ export default new (class Template extends Marko._.Template<{
           >,
       ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default Loader;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-type-args/__snapshots__/tag-type-args.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-type-args/__snapshots__/tag-type-args.expected/components/test-tag.ts
@@ -18,7 +18,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render<T>(
     input: Marko.TemplateInput<Input<T>>,
     stream?: {
@@ -61,3 +61,4 @@ export default new (class Template extends Marko._.Template<{
           Marko._.Relate<__marko_internal_input, Marko.Directives & Input<T>>,
       ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-type-params/__snapshots__/tag-type-params.expected/components/test-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-type-params/__snapshots__/tag-type-params.expected/components/test-tag.ts
@@ -17,7 +17,7 @@ function __marko_internal_template<T, U>(this: void) {
 }
 const __marko_internal_api = "tags";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const TestTag = new (class Template extends Marko._.Template<{
   render<T, U>(
     input: Marko.TemplateInput<Input<T, U>>,
     stream?: {
@@ -76,3 +76,4 @@ export default new (class Template extends Marko._.Template<{
           : never
       >;
 }> {})();
+export default TestTag;

--- a/packages/language-server/src/__tests__/fixtures/script/tag-var-mutation-patterns/__snapshots__/tag-var-mutation-patterns.expected/components/my-tag.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tag-var-mutation-patterns/__snapshots__/tag-var-mutation-patterns.expected/components/my-tag.ts
@@ -20,7 +20,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const MyTag = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -55,3 +55,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default MyTag;

--- a/packages/language-server/src/__tests__/fixtures/script/tags-api-basic/__snapshots__/tags-api-basic.expected/components/fancy-button/index.ts
+++ b/packages/language-server/src/__tests__/fixtures/script/tags-api-basic/__snapshots__/tags-api-basic.expected/components/fancy-button/index.ts
@@ -26,7 +26,7 @@ export { type Component };
 })();
 const __marko_internal_api = "class";
 export { __marko_internal_api as "~api" };
-export default new (class Template extends Marko._.Template<{
+const FancyButton = new (class Template extends Marko._.Template<{
   render(
     input: Marko.TemplateInput<Input>,
     stream?: {
@@ -61,3 +61,4 @@ export default new (class Template extends Marko._.Template<{
       Marko._.Relate<__marko_internal_input, Marko.Directives & Input>,
   ) => Marko._.ReturnWithScope<__marko_internal_input, void>;
 }> {})();
+export default FancyButton;

--- a/packages/language-tools/src/extractors/script/index.ts
+++ b/packages/language-tools/src/extractors/script/index.ts
@@ -28,6 +28,7 @@ import {
   type Mutation,
 } from "./util/attach-scopes";
 import { getComponentFilename } from "./util/get-component-filename";
+import { getComponentName } from "./util/get-component-name";
 import { getRuntimeAPI, RuntimeAPI } from "./util/get-runtime-api";
 import { isTextOnlyScript } from "./util/is-text-only-script";
 import getJSDocInputType from "./util/jsdoc-input-type";
@@ -470,7 +471,20 @@ function ${templateName}() {\n`);
       );
     }
 
-    this.#extractor.write(`export default new `).anchor(START_OF_FILE);
+    // Naming the default export's binding lets TypeScript offer a clean
+    // `import MyButton` for auto-imports instead of the file-derived
+    // `MyButtonMarko`. Only auto-discoverable tags get a name, and only when it
+    // is not already referenced in the source — a cheap conservative check that
+    // keeps the anonymous default export rather than risk a redeclaration.
+    const componentName = getComponentName(this.#filename);
+    const exportName =
+      componentName && !this.#code.includes(componentName)
+        ? componentName
+        : undefined;
+
+    this.#extractor
+      .write(exportName ? `const ${exportName} = new ` : `export default new `)
+      .anchor(START_OF_FILE);
     if (this.#scriptLang === ScriptLang.ts) {
       this.#extractor.write(`(
   class Template extends ${templateOverrideClass} {}
@@ -482,6 +496,9 @@ function ${templateName}() {\n`);
    */
   class Template extends ${templateBaseClass} {}
 );\n`);
+    }
+    if (exportName) {
+      this.#extractor.write(`export default ${exportName};\n`);
     }
 
     this.#writeComments(program);

--- a/packages/language-tools/src/extractors/script/util/get-component-name.ts
+++ b/packages/language-tools/src/extractors/script/util/get-component-name.ts
@@ -1,0 +1,33 @@
+// Matches a `.marko` file that Marko auto-discovers as a tag through a
+// `components`/`tags` directory, capturing the tag name (group 1):
+//
+// - `components/foo.marko`       -> foo
+// - `components/foo/index.marko` -> foo
+// - `components/foo/foo.marko`   -> foo (file matching its directory)
+//
+// The optional group consumes the directory layouts; `\1` ties the self-named
+// file back to its directory.
+const REG_DISCOVERABLE_TAG =
+  /[\\/](?:components|tags)[\\/]([^\\/]+?)(?:[\\/](?:index|\1))?(?:\.d)?\.marko$/i;
+// Upper-cases the first letter/digit of each `-`/`_`/`.`-separated word.
+const REG_WORD_START = /(?:^|[^\p{L}\p{N}]+)([\p{L}\p{N}])/gu;
+
+/**
+ * Returns a PascalCase identifier to name a component's default export binding,
+ * but only when the file is auto-discoverable as a Marko tag (through a
+ * `components`/`tags` directory) and the tag name normalizes to a valid
+ * identifier. Otherwise `undefined`, so the extractor keeps a plain anonymous
+ * `export default`. Naming the binding lets auto-imports read `import MyButton`
+ * rather than TypeScript's file-derived `MyButtonMarko`.
+ */
+export function getComponentName(filePath: string): string | undefined {
+  const match = REG_DISCOVERABLE_TAG.exec(filePath);
+  if (!match) return;
+
+  const name = match[1].replace(REG_WORD_START, (_, char) =>
+    char.toUpperCase(),
+  );
+
+  // Skip naming when it would not be a valid identifier (eg `3d-view`).
+  return /^\p{L}/u.test(name) ? name : undefined;
+}


### PR DESCRIPTION
Marko components that are auto-discoverable as tags (files under a `components`/`tags` directory) now name their default export's binding, so TypeScript offers a clean identifier for auto-imports instead of the file-derived default:

- `components/my-button.marko` → `import MyButton from "..."` (was `MyButtonMarko`)
- `components/foo/index.marko` → `import Foo` (was `import index`)

This works natively in the language server, the ts-plugin, and `@marko/type-check` — TypeScript indexes the component under its real name, so it's discoverable by that name too.

The name is the PascalCased tag name (`components/foo.marko`, `components/foo/index.marko`, and `components/foo/foo.marko` all → `Foo`; same under `tags/`). It's skipped — keeping the plain anonymous `export default` — when the file isn't discoverable, when the tag name wouldn't be a valid identifier (e.g. `3d-view`), or when the name already appears in the source (a cheap conservative check that avoids redeclaring an existing binding).

---
_Generated by [Claude Code](https://claude.ai/code/session_0162Xi857XVdqA6YfRUz9FTp)_