### PR TITLE
feat: complete tag names inside shorthand import strings

### DIFF
--- a/.changeset/shorthand-import-tag-completion.md
+++ b/.changeset/shorthand-import-tag-completion.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-server": patch
+---
+
+Complete the tag name inside a shorthand import string (eg `import Foo from "<foo>"`) the same way an open tag name is completed: suggestions filter and sort on the bare tag name, are prioritized above TypeScript's module-specifier completions, and only add the closing `>` when it isn't already present.

--- a/packages/language-server/src/__tests__/import-tag-complete.test.ts
+++ b/packages/language-server/src/__tests__/import-tag-complete.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+
+import { Project } from "@marko/language-tools";
+import path from "path";
+import { CancellationToken, type TextEdit } from "vscode-languageserver";
+import { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
+
+import { documents } from "../service";
+import MarkoPlugin from "../service/marko";
+
+Project.setDefaultTypePaths({
+  internalTypesFile:
+    require.resolve("@marko/language-tools/marko.internal.d.ts"),
+  markoTypesFile: require.resolve("marko/index.d.ts"),
+});
+
+// Tag completion resolves against the taglib's filesystem scan, so this reuses a
+// fixture that already ships discoverable `components/TestTagA.marko` /
+// `TestTagB.marko`. The consumer is an in-memory file in that directory.
+const FIXTURE_DIR = path.join(
+  __dirname,
+  "fixtures",
+  "script",
+  "prefer-local-identifier-tag-name",
+);
+
+// Completes the `<...>` tag-name slot of `importLine` (with the cursor
+// `cursorInName` characters into the name) and returns the `TestTagA` item plus
+// the line that results from applying its edit.
+let runId = 0;
+async function completeImport(importLine: string, cursorInName: number) {
+  const uri = URI.file(
+    path.join(FIXTURE_DIR, `__import-${runId++}.marko`),
+  ).toString();
+  const text = `${importLine}\n`;
+  documents.doOpen({
+    textDocument: { uri, languageId: "marko", version: 1, text },
+  });
+  const doc = documents.get(uri)!;
+  try {
+    const offset = importLine.indexOf('"<') + 2 + cursorInName;
+    const result = await MarkoPlugin.doComplete!(
+      doc,
+      {
+        textDocument: { uri },
+        position: doc.positionAt(offset),
+        context: { triggerKind: 1 },
+      } as never,
+      CancellationToken.None,
+    );
+    const items = Array.isArray(result) ? result : (result?.items ?? []);
+    const item = items.find((i) => i.label === "TestTagA");
+    return {
+      item,
+      applied: item
+        ? TextDocument.applyEdits(doc, [item.textEdit as TextEdit]).split(
+            "\n",
+          )[0]
+        : undefined,
+    };
+  } finally {
+    documents.doClose({ textDocument: { uri } });
+  }
+}
+
+describe("shorthand import tag-name completion", () => {
+  it("completes a bare tag name with priority, like an open tag", async () => {
+    const { item, applied } = await completeImport(
+      'import Foo from "<TestTagA>"',
+      0,
+    );
+    assert.ok(item, "expected a TestTagA completion");
+    assert.equal(item.label, "TestTagA");
+    assert.ok(item.sortText?.startsWith("0"), "should be prioritized");
+    assert.equal(applied, 'import Foo from "<TestTagA>"');
+  });
+
+  it("completes a half-typed name and keeps the existing `>`", async () => {
+    const { applied } = await completeImport('import Foo from "<TestTagA>"', 4);
+    assert.equal(applied, 'import Foo from "<TestTagA>"');
+  });
+
+  it("adds the closing `>` when the user has not typed it yet", async () => {
+    const { applied } = await completeImport('import Foo from "<TestTagA"', 4);
+    assert.equal(applied, 'import Foo from "<TestTagA>"');
+  });
+
+  it("completes into an empty shorthand", async () => {
+    const { applied } = await completeImport('import Foo from "<>"', 0);
+    assert.equal(applied, 'import Foo from "<TestTagA>"');
+  });
+});

--- a/packages/language-server/src/service/marko/complete/Import.ts
+++ b/packages/language-server/src/service/marko/complete/Import.ts
@@ -5,7 +5,9 @@ import getTagNameCompletion from "../util/get-tag-name-completion";
 import type { CompletionMeta, CompletionResult } from ".";
 
 const staticImportReg = /^\s*(?:static|client|server) import\b/;
-const importTagReg = /(['"])<((?:[^'"\\>]|\\.)*)>?\1/;
+// Captures the quote, the shorthand tag name, and whether the closing `>` is
+// already present (eg `"<foo>"`, or a half-typed `"<fo`).
+const importTagReg = /(['"])<((?:[^'"\\>]|\\.)*)(>?)\1/;
 
 export function Import({
   node,
@@ -18,41 +20,42 @@ export function Import({
   }
 
   const match = importTagReg.exec(value);
-  if (match) {
-    const [{ length }] = match;
-    const fromStart = node.start + match.index;
-    const range = parsed.locationAt({
-      start: fromStart + 1,
-      end: fromStart + length - 1,
-    });
+  if (!match) return;
 
-    const result: CompletionItem[] = [];
+  const [, , name, close] = match;
+  // Complete just the tag name slot (between `<` and `>`) so it filters and
+  // sorts exactly like an open tag name, and append the closing `>` only when
+  // the user has not typed it yet so the shorthand stays valid.
+  const nameStart = node.start + match.index + 2; // skip the opening quote and `<`
+  const range = parsed.locationAt({
+    start: nameStart,
+    end: nameStart + name.length,
+  });
+  const suffix = close ? "" : ">";
 
-    for (const tag of lookup.getTagsSorted()) {
-      if (
-        (tag.template || tag.renderer) &&
-        !(
-          tag.html ||
-          tag.parser ||
-          tag.translator ||
-          tag.isNestedTag ||
-          tag.name === "*" ||
-          tag.parseOptions?.statement ||
-          /^@?marko[/-]/.test(tag.taglibId) ||
-          (tag.name[0] === "_" && /[\\/]node_modules[\\/]/.test(tag.filePath))
-        )
-      ) {
-        const completion = getTagNameCompletion({
-          tag,
-          importer: filename,
-        });
+  const result: CompletionItem[] = [];
 
-        completion.label = `<${completion.label}>`;
-        completion.textEdit = TextEdit.replace(range, completion.label);
-        result.push(completion);
-      }
+  for (const tag of lookup.getTagsSorted()) {
+    if (
+      (tag.template || tag.renderer) &&
+      !(
+        tag.html ||
+        tag.parser ||
+        tag.translator ||
+        tag.isNestedTag ||
+        tag.name === "*" ||
+        tag.parseOptions?.statement ||
+        /^@?marko[/-]/.test(tag.taglibId) ||
+        (tag.name[0] === "_" && /[\\/]node_modules[\\/]/.test(tag.filePath))
+      )
+    ) {
+      const completion = getTagNameCompletion({ tag, importer: filename });
+      // Prioritize over TypeScript's module specifier completions.
+      completion.sortText = `0${completion.label}`;
+      completion.textEdit = TextEdit.replace(range, completion.label + suffix);
+      result.push(completion);
     }
-
-    return result;
   }
+
+  return result;
 }


### PR DESCRIPTION
Shorthand Marko tag imports (eg `import Foo from "<foo>"`) now complete the tag name inside the `<…>` slot the same way an open tag does:

- suggestions filter and sort on the **bare tag name** (type `my` → matches `my-comp`), instead of on the full `<my-comp>` string
- they're **prioritized above** TypeScript's module-specifier completions, matching the open-tag handler
- the closing `>` is only appended when it isn't already present, so `"<foo`, `"<foo>"`, and empty `"<>"` all resolve to `import Foo from "<foo>"`

The existing tag filter (only importable `template`/`renderer` tags) is preserved.

Covered by a new focused test exercising the full name, half-typed (with and without `>`), and empty `<>` cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_0162Xi857XVdqA6YfRUz9FTp)_