### PR TITLE
fix: scope ts-plugin to Marko projects to avoid Vue conflict

### DIFF
--- a/.changeset/ts-plugin-scope-to-marko-projects.md
+++ b/.changeset/ts-plugin-scope-to-marko-projects.md
@@ -1,0 +1,6 @@
+---
+"@marko/language-server": patch
+"@marko/ts-plugin": patch
+---
+
+Stop the TypeScript Server plugin from interfering with other plugins (such as Vue's) in projects that don't use Marko. Because the plugin is injected into the editor's shared TypeScript Server for every workspace, it previously patched the shared language service host even where no Marko files exist, which broke diagnostics, go-to-definition, and rename in `.vue` files. It now stays inert unless the project actually uses Marko.

--- a/packages/language-server/src/ts-plugin/index.ts
+++ b/packages/language-server/src/ts-plugin/index.ts
@@ -6,6 +6,7 @@ import {
   Processors,
   Project,
 } from "@marko/language-tools";
+import path from "path";
 import type ts from "typescript/lib/tsserverlibrary";
 
 import { START_POSITION } from "../utils/constants";
@@ -34,6 +35,10 @@ export function init({ typescript: ts }: InitOptions): ts.server.PluginModule {
         languageService: ls,
         languageServiceHost: lsh,
       } = info;
+
+      if (!projectUsesMarko(ts, lsh)) {
+        return ls;
+      }
 
       try {
         const { projectService: ps } = tsProject;
@@ -185,6 +190,30 @@ export function init({ typescript: ts }: InitOptions): ts.server.PluginModule {
       return ls;
     },
   };
+}
+
+function projectUsesMarko(
+  ts: typeof import("typescript/lib/tsserverlibrary"),
+  host: ts.LanguageServiceHost,
+) {
+  try {
+    for (const fileName of host.getScriptFileNames()) {
+      if (/\.marko$/.test(fileName)) {
+        return true;
+      }
+    }
+
+    return Boolean(
+      ts.resolveModuleName(
+        "marko",
+        path.join(host.getCurrentDirectory(), "_.ts"),
+        { moduleResolution: ts.ModuleResolutionKind.Bundler },
+        host,
+      ).resolvedModule,
+    );
+  } catch {
+    return true;
+  }
 }
 
 function mapTextSpans<


### PR DESCRIPTION
Installing the Marko extension breaks TypeScript features (diagnostics, go-to-definition, rename) in `.vue` files.

The Marko TypeScript Server plugin is registered globally (`typescriptServerPlugins` + `enableForWorkspaceTypeScriptVersions`), so it loads into the editor's shared TypeScript Server for every workspace — including Vue projects with no Marko files — and patches the shared language service host. That disrupts Vue's plugin and surfaces spurious diagnostics on its generated `__VLS_*` virtual code.

The plugin now stays inert unless the project actually uses Marko (a `.marko` file is present, or `marko` resolves as a dependency), so it no longer touches non-Marko projects.

Closes #420 