### PR TITLE
Add server restart/reload commands for Marko files

### DIFF
--- a/.changeset/marko-ts-server-commands.md
+++ b/.changeset/marko-ts-server-commands.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Add a "Marko: Restart Marko and TS Servers" command, and list the built-in "TypeScript: Reload Project" command in the Command Palette for `.marko` files.

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -44,6 +44,10 @@
       {
         "command": "marko.formatToHtmlMode",
         "title": "Marko: Format: Force Html Mode"
+      },
+      {
+        "command": "marko.restartServer",
+        "title": "Marko: Restart Marko and TS Servers"
       }
     ],
     "configuration": {
@@ -108,6 +112,14 @@
         "configuration": "./marko.configuration.json"
       }
     ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "typescript.reloadProjects",
+          "when": "editorLangId == marko"
+        }
+      ]
+    },
     "typescriptServerPlugins": [
       {
         "name": "marko-ts-plugin",

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -136,6 +136,22 @@ export async function activate(ctx: ExtensionContext) {
     }),
   );
 
+  ctx.subscriptions.push(
+    commands.registerCommand("marko.restartServer", async () => {
+      const restartMarko = (async () => {
+        if (client.isRunning()) {
+          await client.stop();
+        }
+        await client.start();
+      })();
+
+      await Promise.all([
+        restartMarko,
+        commands.executeCommand("typescript.restartTsServer"),
+      ]);
+    }),
+  );
+
   // Start the client. This will also launch the server
   await client.start();
 }


### PR DESCRIPTION
Adds a "Marko: Restart Marko and TS Servers" command that restarts the Marko language server and the TypeScript server (which hosts the `marko-ts-plugin`) together, and lists the built-in "TypeScript: Reload Project" command in the Command Palette while a `.marko` file is focused.

Previously these were unavailable from `.marko` files because the TypeScript extension gates its commands on `typescript.isManagedFile`, so users had to switch to a `.ts` file or reload the window after changing type definitions in a `.marko` file.

Closes #464

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZufF1yZmgerBfguadrmUQ)_