### PR TITLE
feat: show compiled Marko template output

### DIFF
--- a/.changeset/show-compiled-output.md
+++ b/.changeset/show-compiled-output.md
@@ -1,0 +1,6 @@
+---
+"@marko/language-server": patch
+"marko-vscode": patch
+---
+
+Add "Show Compiled DOM/HTML Output" debug commands to view the JavaScript a Marko template compiles to for the `dom` or `html` target (always esm).

--- a/packages/language-server/src/__tests__/compiled-output.test.ts
+++ b/packages/language-server/src/__tests__/compiled-output.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+
+import { Project } from "@marko/language-tools";
+import path from "path";
+import { URI } from "vscode-uri";
+
+import MarkoLanguageService, { documents } from "../service";
+
+Project.setDefaultTypePaths({
+  internalTypesFile:
+    require.resolve("@marko/language-tools/marko.internal.d.ts"),
+  markoTypesFile: require.resolve("marko/index.d.ts"),
+});
+
+const FIXTURE_DIR = path.join(__dirname, "fixtures");
+
+type CompiledOutput = { language: string; content: string } | undefined;
+
+function open(name: string, text: string) {
+  // Point the virtual document at a real directory so the compiler can resolve
+  // taglibs, but keep it open in-memory so the source comes from `text`.
+  const uri = URI.file(path.join(FIXTURE_DIR, name)).toString();
+  documents.doOpen({
+    textDocument: { uri, languageId: "marko", version: 1, text },
+  });
+  return uri;
+}
+
+const compile = (uri: string, output: "dom" | "html") =>
+  MarkoLanguageService.commands["$/showCompiledOutput"]({
+    uri,
+    output,
+  }) as Promise<CompiledOutput>;
+
+const SOURCE = "<let/count=0 />\n<button>${count}</button>\n";
+
+describe("showCompiledOutput command", () => {
+  it("compiles to esm dom output", async () => {
+    const uri = open("compiled-output-dom.marko", SOURCE);
+    const result = await compile(uri, "dom");
+
+    assert.ok(result, "expected a result");
+    assert.equal(result.language, "javascript");
+    // esm output uses `import`/`export`, never the cjs equivalents.
+    assert.match(result.content, /\bexport\b/);
+    assert.doesNotMatch(result.content, /\brequire\(/);
+    assert.doesNotMatch(result.content, /\bmodule\.exports\b/);
+    // The dom target pulls from the runtime's dom entry.
+    assert.match(result.content, /from\s*["'][^"']*\/dom["']/);
+  });
+
+  it("compiles to esm html output", async () => {
+    const uri = open("compiled-output-html.marko", SOURCE);
+    const result = await compile(uri, "html");
+
+    assert.ok(result, "expected a result");
+    assert.equal(result.language, "javascript");
+    assert.match(result.content, /\bexport\b/);
+    assert.doesNotMatch(result.content, /\brequire\(/);
+    assert.doesNotMatch(result.content, /\bmodule\.exports\b/);
+    // The html target pulls from the runtime's html entry.
+    assert.match(result.content, /from\s*["'][^"']*\/html["']/);
+  });
+
+  it("produces different output for the dom and html targets", async () => {
+    const uri = open("compiled-output-both.marko", SOURCE);
+    const [dom, html] = await Promise.all([
+      compile(uri, "dom"),
+      compile(uri, "html"),
+    ]);
+
+    assert.ok(dom && html);
+    assert.notEqual(dom.content, html.content);
+  });
+
+  it("strips typescript types from the compiled output", async () => {
+    const uri = open(
+      "compiled-output-ts.marko",
+      "<let/count: number = 0 />\n<button>${count}</button>\n",
+    );
+    const result = await compile(uri, "dom");
+
+    assert.ok(result, "expected a result");
+    assert.doesNotMatch(result.content, /:\s*number/);
+  });
+
+  it("reports compile errors as plaintext instead of throwing", async () => {
+    const uri = open("compiled-output-error.marko", "<div class=>\n");
+    const result = await compile(uri, "dom");
+
+    assert.ok(result, "expected a result");
+    assert.equal(result.language, "plaintext");
+    assert.ok(result.content.length > 0);
+  });
+});

--- a/packages/language-server/src/service/html/index.ts
+++ b/packages/language-server/src/service/html/index.ts
@@ -23,7 +23,7 @@ const HTMLService: Partial<Plugin> = {
   commands: {
     "$/showHtmlOutput": async (uri: string) => {
       const doc = get(uri);
-      if (!doc) return;
+      if (doc?.languageId !== "marko") return;
 
       const { extracted } = extract(doc);
 

--- a/packages/language-server/src/service/marko/compile.ts
+++ b/packages/language-server/src/service/marko/compile.ts
@@ -1,0 +1,59 @@
+import { Project } from "@marko/language-tools";
+import path from "path";
+import * as prettier from "prettier";
+import type { TextDocument } from "vscode-languageserver-textdocument";
+import { URI } from "vscode-uri";
+
+export type CompiledOutputTarget = "dom" | "html";
+
+export interface CompiledOutput {
+  language: string;
+  content: string;
+}
+
+/**
+ * Compiles a Marko document to its final JavaScript output for the requested
+ * target (`dom` for client side or `html` for server side rendering).
+ *
+ * Compilation always assumes esm mode and reuses the translator/config resolved
+ * for the document's project, so the output reflects whichever Marko runtime
+ * (eg Marko 5 vs Marko 6) the project depends on.
+ */
+export async function compileDocument(
+  doc: TextDocument,
+  output: CompiledOutputTarget,
+): Promise<CompiledOutput> {
+  const { fsPath, scheme } = URI.parse(doc.uri);
+  // Untitled documents have no path on disk, fall back to the cwd so the
+  // compiler still has a real directory to resolve taglibs against.
+  const filename =
+    scheme === "file" ? fsPath : path.join(process.cwd(), "untitled.marko");
+  const dir = path.dirname(filename);
+  const compiler = Project.getCompiler(dir);
+  const config = Project.getConfig(dir);
+
+  try {
+    const { code } = await compiler.compile(doc.getText(), filename, {
+      ...config,
+      output,
+      modules: "esm",
+      sourceMaps: false,
+      ast: false,
+      code: true,
+    });
+
+    return {
+      language: "javascript",
+      content: await prettier
+        .format(code!, { parser: "babel" })
+        .catch(() => code!),
+    };
+  } catch (err) {
+    // Surface the compile error in the output document so the failure is
+    // actionable rather than silently swallowed.
+    return {
+      language: "plaintext",
+      content: err instanceof Error ? (err.stack ?? err.message) : String(err),
+    };
+  }
+}

--- a/packages/language-server/src/service/marko/index.ts
+++ b/packages/language-server/src/service/marko/index.ts
@@ -1,6 +1,7 @@
 import * as documents from "../../utils/text-documents";
 import type { Plugin } from "../types";
 import { doCodeActionResolve, doCodeActions, initialize } from "./code-actions";
+import { compileDocument, type CompiledOutputTarget } from "./compile";
 import { doComplete } from "./complete";
 import { findDefinition } from "./definition";
 import { findDocumentLinks } from "./document-links";
@@ -31,6 +32,17 @@ export default {
       const doc = documents.get(docURI)!;
       const formatted = await formatDocument(doc, options);
       return formatted;
+    },
+    "$/showCompiledOutput": async ({
+      uri,
+      output,
+    }: {
+      uri: string;
+      output: CompiledOutputTarget;
+    }) => {
+      const doc = documents.get(uri);
+      if (doc?.languageId !== "marko") return;
+      return compileDocument(doc, output);
     },
   },
 } as Partial<Plugin>;

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -38,6 +38,14 @@
         "title": "Marko: Debug: Show Extracted Static HTML Output"
       },
       {
+        "command": "marko.showCompiledDomOutput",
+        "title": "Marko: Debug: Show Compiled DOM Output"
+      },
+      {
+        "command": "marko.showCompiledHtmlOutput",
+        "title": "Marko: Debug: Show Compiled HTML Output"
+      },
+      {
         "command": "marko.formatToConciseMode",
         "title": "Marko: Format: Force Concise Mode"
       },

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -69,59 +69,43 @@ export async function activate(ctx: ExtensionContext) {
   });
 
   ctx.subscriptions.push(
-    commands.registerCommand("marko.showScriptOutput", async () => {
-      if (!window.activeTextEditor) {
-        window.showErrorMessage(
-          "You must have an open Marko file to view the script output for.",
-        );
-        return;
-      }
-
-      const result = await client.sendRequest<
-        { language: string; content: string } | undefined
-      >("$/showScriptOutput", window.activeTextEditor.document.uri.toString());
-
-      if (result) {
-        await window.showTextDocument(
-          await workspace.openTextDocument(result),
-          {
-            preview: true,
-            viewColumn: ViewColumn.Beside,
-          },
-        );
-      } else {
-        window.showErrorMessage("Unable to extract script for Marko document.");
-      }
-    }),
+    commands.registerCommand("marko.showScriptOutput", () =>
+      showOutput(
+        "$/showScriptOutput",
+        (uri) => uri,
+        "Unable to extract script for Marko document.",
+      ),
+    ),
   );
 
   ctx.subscriptions.push(
-    commands.registerCommand("marko.showHtmlOutput", async () => {
-      if (!window.activeTextEditor) {
-        window.showErrorMessage(
-          "You must have an open Marko file to view the static HTML output for.",
-        );
-        return;
-      }
+    commands.registerCommand("marko.showHtmlOutput", () =>
+      showOutput(
+        "$/showHtmlOutput",
+        (uri) => uri,
+        "Unable to extract static HTML for Marko document.",
+      ),
+    ),
+  );
 
-      const result = await client.sendRequest<
-        { language: string; content: string } | undefined
-      >("$/showHtmlOutput", window.activeTextEditor.document.uri.toString());
+  ctx.subscriptions.push(
+    commands.registerCommand("marko.showCompiledDomOutput", () =>
+      showOutput(
+        "$/showCompiledOutput",
+        (uri) => ({ uri, output: "dom" }),
+        "Unable to compile DOM output for Marko document.",
+      ),
+    ),
+  );
 
-      if (result) {
-        await window.showTextDocument(
-          await workspace.openTextDocument(result),
-          {
-            preview: true,
-            viewColumn: ViewColumn.Beside,
-          },
-        );
-      } else {
-        window.showErrorMessage(
-          "Unable to extract static HTML for Marko document.",
-        );
-      }
-    }),
+  ctx.subscriptions.push(
+    commands.registerCommand("marko.showCompiledHtmlOutput", () =>
+      showOutput(
+        "$/showCompiledOutput",
+        (uri) => ({ uri, output: "html" }),
+        "Unable to compile HTML output for Marko document.",
+      ),
+    ),
   );
 
   ctx.subscriptions.push(
@@ -162,6 +146,33 @@ export function deactivate(): Thenable<void> | void {
   }
 
   return client.stop();
+}
+
+async function showOutput(
+  request: string,
+  getParams: (uri: string) => unknown,
+  unavailableMessage: string,
+) {
+  const editor = window.activeTextEditor;
+  if (editor?.document.languageId !== "marko") {
+    window.showErrorMessage(
+      "You must have an open Marko file to view its output.",
+    );
+    return;
+  }
+
+  const result = await client.sendRequest<
+    { language: string; content: string } | undefined
+  >(request, getParams(editor.document.uri.toString()));
+
+  if (result) {
+    await window.showTextDocument(await workspace.openTextDocument(result), {
+      preview: true,
+      viewColumn: ViewColumn.Beside,
+    });
+  } else {
+    window.showErrorMessage(unavailableMessage);
+  }
 }
 
 async function formatForced(mode: "concise" | "html") {


### PR DESCRIPTION
Adds **Show Compiled DOM Output** and **Show Compiled HTML Output** debug commands that display the JavaScript a Marko template compiles to for the `dom` or `html` target (always esm), via a new `$/showCompiledOutput` LSP request. Existing show-output commands are unified to share the same handling and Marko-file guard.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbRV6TdronXsNPWWag8cVS)_