### PR TITLE
fix: strip non-identifier chars from bracket variant filenames in getComponentName

### DIFF
--- a/.changeset/fix-bracket-variant-component-name.md
+++ b/.changeset/fix-bracket-variant-component-name.md
@@ -1,5 +1,9 @@
 ---
+"@marko/language-server": patch
 "@marko/language-tools": patch
+"@marko/ts-plugin": patch
+"@marko/type-check": patch
+"marko-vscode": patch
 ---
 
 Fix `getComponentName` leaving a trailing `]` in the generated identifier when a component file has a bracketed variant suffix (e.g. `my-button[variant].marko`). The stray `]` produced invalid TypeScript (`const MyButtonVariant] = new …`) which caused TS1005/TS1134/TS1389 parse errors.

--- a/.changeset/fix-bracket-variant-component-name.md
+++ b/.changeset/fix-bracket-variant-component-name.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-tools": patch
+---
+
+Fix `getComponentName` leaving a trailing `]` in the generated identifier when a component file has a bracketed variant suffix (e.g. `my-button[variant].marko`). The stray `]` produced invalid TypeScript (`const MyButtonVariant] = new …`) which caused TS1005/TS1134/TS1389 parse errors.

--- a/packages/language-server/src/__tests__/component-auto-import.test.ts
+++ b/packages/language-server/src/__tests__/component-auto-import.test.ts
@@ -111,6 +111,18 @@ describe("marko component default export naming", () => {
     );
   });
 
+  it("strips bracket variant suffixes from the identifier", async () => {
+    // Some frameworks place variant files under `tags/` or `components/` with a
+    // bracketed suffix, e.g. `my-button[variant].marko`. The bracket must not
+    // survive into the generated identifier: before the fix, `REG_WORD_START`
+    // left a trailing `]`, producing `const MyButtonVariant] = new (`, which
+    // TypeScript cannot parse (TS1005/TS1134/TS1389).
+    const out = await defaultExport("tags/my-button[variant].marko");
+    assert.doesNotMatch(out, /\]/, "identifier must not contain `]`");
+    assert.match(out, /const MyButtonVariant = new \(/);
+    assert.match(out, /export default MyButtonVariant;/);
+  });
+
   it("offers a clean `import MyComponent` auto-import", async () => {
     const { uris, dispose } = openAll({
       "components/my-component.marko": "<div/>\n",

--- a/packages/language-tools/src/extractors/script/util/get-component-name.ts
+++ b/packages/language-tools/src/extractors/script/util/get-component-name.ts
@@ -24,9 +24,9 @@ export function getComponentName(filePath: string): string | undefined {
   const match = REG_DISCOVERABLE_TAG.exec(filePath);
   if (!match) return;
 
-  const name = match[1].replace(REG_WORD_START, (_, char) =>
-    char.toUpperCase(),
-  );
+  const name = match[1]
+    .replace(REG_WORD_START, (_, char) => char.toUpperCase())
+    .replace(/[^\p{L}\p{N}]/gu, "");
 
   // Skip naming when it would not be a valid identifier (eg `3d-view`).
   return /^\p{L}/u.test(name) ? name : undefined;


### PR DESCRIPTION
## Summary

- `getComponentName` converts a file's basename to a PascalCase identifier using `REG_WORD_START`, which upper-cases each letter that follows a run of non-word characters. However, a trailing non-word character with nothing after it (e.g. the `]` in `my-button[variant].marko`) is never consumed, leaving it in the output.
- This produced identifiers like `MyButtonVariant]`, causing TypeScript parse errors (TS1005, TS1134, TS1389) for any component file whose name contains a bracketed variant suffix.
- Fix: add a second `.replace(/[^\p{L}\p{N}]/gu, "")` pass to strip any remaining non-identifier characters after the PascalCase conversion.

## Test plan

- [ ] New test case `"strips bracket variant suffixes from the identifier"` in `component-auto-import.test.ts` covers a `tags/my-button[variant].marko` file and asserts the generated identifier contains no `]`
- [ ] Full test suite passes (`185 passing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)