### PR TITLE
fix: stop auto-closing the `|` pair

### DIFF
--- a/.changeset/tag-params-pipe-auto-close.md
+++ b/.changeset/tag-params-pipe-auto-close.md
@@ -1,0 +1,5 @@
+---
+"marko-vscode": patch
+---
+
+Stop auto-closing the `|` pair. It's a tag-params delimiter, but it more often shows up as an operator (eg a TS union `x: A | B` in tag params), where auto-closing inserted a stray `|`. Bracket matching and wrapping a selection in `|` are unaffected.

--- a/packages/vscode/marko.configuration.json
+++ b/packages/vscode/marko.configuration.json
@@ -16,7 +16,6 @@
     { "open": "{", "close": "}" },
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
-    { "open": "|", "close": "|" },
     { "open": "'", "close": "'", "notIn": ["string", "comment"] },
     { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
     { "open": "`", "close": "`", "notIn": ["string", "comment"] },


### PR DESCRIPTION
## Problem

`|` was an auto-closing pair, so typing it inserted a matching `|`. It's a tag-params delimiter (`<for|item|>`), but it more often shows up as an **operator** — a TS union in tag params (`<my-tag|x: A | B|>`), `||` in an argument, etc. — where the auto-inserted `|` is just in the way.

## Fix

Remove `|` from `autoClosingPairs` in `marko.configuration.json`.

Making it context-sensitive (auto-close only at the params-start position) isn't possible statically — VS Code takes `autoClosingPairs` from the document's outer language, never the embedded one ([microsoft/vscode#133397](https://github.com/microsoft/vscode/issues/133397)), and `notIn` only distinguishes `comment`/`string`/`regex`. Any "only at param-start" behavior needs a per-keystroke runtime workaround; not worth it for one auto-inserted character, so this just drops the pair.

`brackets` (matching) and `surroundingPairs` (wrap a selection in `|`) keep their `|` entries, so those still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
