### PR TITLE
fix: register file watchers so non-VS Code clients (e.g. Zed) stay in sync

### DIFF
--- a/.changeset/quiet-zed-file-watch.md
+++ b/.changeset/quiet-zed-file-watch.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-server": patch
+---
+
+Register file watchers with the client so on-disk changes to Marko-relevant files (imported components, TS modules, styles, tag definitions, tsconfig, and dependency manifests) invalidate the server's caches. Previously only VS Code — which watches these files client-side — stayed in sync; editors like Zed left intellisense stale until the server restarted.

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -6,6 +6,7 @@ import {
   createConnection,
   type DefinitionLink,
   Diagnostic,
+  DidChangeWatchedFilesNotification,
   ProposedFeatures,
   TextDocumentSyncKind,
 } from "vscode-languageserver/node";
@@ -29,6 +30,15 @@ if (
 const connection = createConnection(ProposedFeatures.all);
 const prevDiags = new WeakMap<TextDocument, Diagnostic[]>();
 let diagnosticTimeout: ReturnType<typeof setTimeout> | undefined;
+let canRegisterFileWatchers = false;
+
+// On-disk changes to these files affect Marko intellisense (imported
+// components, TS modules, styles, tag definitions, tsconfig, and dependency
+// manifests). VS Code's client watches them via `synchronize.fileEvents`, but
+// other clients (e.g. Zed) only send `didChangeWatchedFiles` for watchers the
+// server registers itself — so register them to keep caches in sync everywhere.
+const WATCHED_FILES_GLOB =
+  "**/{*.ts,*.mts,*.cts,*.js,*.mjs,*.cjs,*.marko,*.module.css,*.module.scss,*.module.less,marko.json,marko-tag.json,tsconfig.json,jsconfig.json,package.json,package-lock.json,pnpm-lock.yaml,yarn.lock}";
 
 console.log = (...args: unknown[]) => {
   connection.console.log(args.map((v) => inspect(v)).join(" "));
@@ -40,6 +50,9 @@ process.on("uncaughtException", console.error);
 process.on("unhandledRejection", console.error);
 
 connection.onInitialize(async (params) => {
+  canRegisterFileWatchers = Boolean(
+    params.capabilities.workspace?.didChangeWatchedFiles?.dynamicRegistration,
+  );
   setupMessages(connection);
   await service.initialize(params);
 
@@ -85,6 +98,17 @@ connection.onInitialize(async (params) => {
       },
     },
   };
+});
+
+connection.onInitialized(() => {
+  // Ask spec-compliant clients that don't watch files on the server's behalf
+  // (e.g. Zed) to notify us of on-disk changes to Marko-relevant files. VS Code
+  // already watches these via its client-side `synchronize.fileEvents`.
+  if (canRegisterFileWatchers) {
+    void connection.client.register(DidChangeWatchedFilesNotification.type, {
+      watchers: [{ globPattern: WATCHED_FILES_GLOB }],
+    });
+  }
 });
 
 workspace.setup(connection);


### PR DESCRIPTION
The language server only invalidates its cached view of dependency files (imported components, TS modules, styles, tag definitions, `tsconfig`/`jsconfig`, dependency manifests) when it receives `workspace/didChangeWatchedFiles`. VS Code sends those via a client-side watcher (`synchronize.fileEvents`), but standards-compliant clients like Zed only report changes for watchers the **server** registers itself — so on those editors the Marko intellisense went stale (outdated types, missing completions, unresolved imports) until the server was restarted.

This registers the watchers on `initialized` when the client advertises `workspace.didChangeWatchedFiles.dynamicRegistration`, reusing the same glob the VS Code client already watches. VS Code is unaffected (it continues to watch these files client-side).

Verified against the built server over stdio:
- client advertising `dynamicRegistration` → receives a `client/registerCapability` for `workspace/didChangeWatchedFiles` with the expected glob
- client without it → no registration request is sent


---
_Generated by [Claude Code](https://claude.ai/code/session_01NHhidTBhbgZS92e584TcyL)_