### PR TITLE
chore: upgrade htmljs-parser to ^5.12.1

### DIFF
--- a/.changeset/upgrade-htmljs-parser.md
+++ b/.changeset/upgrade-htmljs-parser.md
@@ -1,0 +1,9 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"@marko/ts-plugin": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Upgrade `htmljs-parser` to `^5.12.1`, which fixes a parse error where a `<`/`>` comparison inside a `static`/`server`/`client` function with a return-type annotation was treated as a generic bracket, swallowing the rest of the template (e.g. breaking "Show Extracted Script Output").

--- a/package-lock.json
+++ b/package-lock.json
@@ -11131,7 +11131,7 @@
         "@marko/compiler": "^5.39.66",
         "@marko/language-tools": "^2.6.2",
         "axe-core": "^4.12.1",
-        "htmljs-parser": "^5.11.0",
+        "htmljs-parser": "^5.12.1",
         "jsdom": "^29.1.1",
         "marko": "^5.39.11",
         "prettier": "^3.8.4",
@@ -11151,6 +11151,12 @@
         "tsx": "^4.22.4"
       }
     },
+    "packages/language-server/node_modules/htmljs-parser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.12.1.tgz",
+      "integrity": "sha512-QnHLg5SWqoH5o8MD4iOWJFtdKSS2lXxtNgyznFXvEeeCK0CTi6URdYtFGkFGDANdq8RZzkuc91KaBgLx2WAhSA==",
+      "license": "MIT"
+    },
     "packages/language-tools": {
       "name": "@marko/language-tools",
       "version": "2.6.2",
@@ -11158,7 +11164,7 @@
       "dependencies": {
         "@luxass/strip-json-comments": "^1.4.0",
         "@marko/compiler": "^5.39.66",
-        "htmljs-parser": "^5.11.0",
+        "htmljs-parser": "^5.12.1",
         "relative-import-path": "^1.0.0"
       },
       "devDependencies": {
@@ -11168,6 +11174,12 @@
         "mitata": "^1.0.34",
         "tsx": "^4.22.4"
       }
+    },
+    "packages/language-tools/node_modules/htmljs-parser": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.12.1.tgz",
+      "integrity": "sha512-QnHLg5SWqoH5o8MD4iOWJFtdKSS2lXxtNgyznFXvEeeCK0CTi6URdYtFGkFGDANdq8RZzkuc91KaBgLx2WAhSA==",
+      "license": "MIT"
     },
     "packages/ts-plugin": {
       "name": "@marko/ts-plugin",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -42,7 +42,7 @@
     "@marko/compiler": "^5.39.66",
     "@marko/language-tools": "^2.6.2",
     "axe-core": "^4.12.1",
-    "htmljs-parser": "^5.11.0",
+    "htmljs-parser": "^5.12.1",
     "jsdom": "^29.1.1",
     "marko": "^5.39.11",
     "prettier": "^3.8.4",

--- a/packages/language-tools/package.json
+++ b/packages/language-tools/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@luxass/strip-json-comments": "^1.4.0",
     "@marko/compiler": "^5.39.66",
-    "htmljs-parser": "^5.11.0",
+    "htmljs-parser": "^5.12.1",
     "relative-import-path": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades `htmljs-parser` to `^5.12.1` (from `^5.11.0`) in `@marko/language-tools` and `@marko/language-server`.

This picks up the [`v5.12.0`](https://github.com/marko-js/htmljs-parser/releases/tag/v5.12.0) fix (htmljs-parser#215) where a `{` following a completed return type now ends the type annotation, so a `<`/`>` comparison in the body of a `static`/`server`/`client` function is no longer parsed as a closing generic bracket. Previously such a function swallowed the rest of the template, breaking script extraction (e.g. "Show Extracted Script Output").