### PR TITLE
fix: import tags from installed packages by their resolved name

### DIFF
--- a/.changeset/tidy-pears-jam.md
+++ b/.changeset/tidy-pears-jam.md
@@ -1,0 +1,5 @@
+---
+"@marko/language-tools": patch
+---
+
+Import tags from installed packages by the name their taglib was resolved through, fixing the types for tags installed into a virtual store (eg pnpm).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,27 +2246,36 @@
       }
     },
     "node_modules/@marko/compiler": {
-      "version": "5.39.66",
-      "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.39.66.tgz",
-      "integrity": "sha512-Xky1vqj1wh8o0Cps/RRgo5p4i8DL+YOSFMvViFfRCTXbMMFNMFH6gUtk1S/oA9yIouhL1iULpxp3F87oWa2ZbA==",
+      "version": "5.41.0",
+      "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.41.0.tgz",
+      "integrity": "sha512-yDMnpKb7q7LtrImxS+kb7kRzGXBOuf99OjsJQTrg7tS9aTw7QKmAGzl9qca/DJYiEhY0GbPSkf/Lqlbmr50QgA==",
       "license": "MIT",
       "dependencies": {
-        "@luxass/strip-json-comments": "^1.4.0",
+        "@luxass/strip-json-comments": "^2.0.1",
         "complain": "^1.6.1",
         "he": "^1.2.0",
-        "htmljs-parser": "^5.10.2",
+        "htmljs-parser": "^5.12.1",
         "jsesc": "^3.1.0",
         "kleur": "^4.1.5",
         "lasso-package-root": "^1.0.1",
         "raptor-regexp": "^1.0.1",
         "raptor-util": "^3.2.0",
-        "relative-import-path": "^1.0.0",
+        "relative-import-path": "^1.0.1",
         "resolve-from": "^5.0.0",
         "self-closing-tags": "^1.0.1",
         "source-map-support": "^0.5.21"
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@marko/compiler/node_modules/@luxass/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@luxass/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-y0rBJcC8idzWD8qnBOXuTAOG/Fudu0reZs/6INyn6aPxCyvk484x9Ib2TAnJtsol2A6IaQB4kmxBSZlR0Crf0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@marko/language-server": {
@@ -6326,9 +6335,9 @@
       }
     },
     "node_modules/htmljs-parser": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.11.0.tgz",
-      "integrity": "sha512-YXdNqYB/FChJMpCG+UfVS/q/zfFErui92zIIduCFT71C3F6+lZWE4K6l5nGfFWQ2w4GCkgH/eEWQ1nWayBXIDQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.12.1.tgz",
+      "integrity": "sha512-QnHLg5SWqoH5o8MD4iOWJFtdKSS2lXxtNgyznFXvEeeCK0CTi6URdYtFGkFGDANdq8RZzkuc91KaBgLx2WAhSA==",
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
@@ -9193,9 +9202,9 @@
       }
     },
     "node_modules/relative-import-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/relative-import-path/-/relative-import-path-1.0.0.tgz",
-      "integrity": "sha512-ZvbtoduKQmD4PZeJPfH6Ql21qUWhaMxiHkIsH+FUnZqKDwNIXBtGg5zRZyHWomiGYk8n5+KMBPK7Mi4D0XWfNg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/relative-import-path/-/relative-import-path-1.0.1.tgz",
+      "integrity": "sha512-mLABwLdOB694B3BW3bNlLOJsWCDhFRBn4BW+gkhILZXJFaymkQWDZom+3qOGYFpbN9K8eeQx8lsy2N+SX/qncQ==",
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -11128,7 +11137,7 @@
       "license": "MIT",
       "dependencies": {
         "@luxass/strip-json-comments": "^1.4.0",
-        "@marko/compiler": "^5.39.66",
+        "@marko/compiler": "^5.41.0",
         "@marko/language-tools": "^2.6.3",
         "axe-core": "^4.12.1",
         "htmljs-parser": "^5.12.1",
@@ -11136,7 +11145,7 @@
         "marko": "^5.39.11",
         "prettier": "^3.8.4",
         "prettier-plugin-marko": "^4.0.9",
-        "relative-import-path": "^1.0.0",
+        "relative-import-path": "^1.0.1",
         "typescript": "^6.0.3",
         "vscode-css-languageservice": "^6.3.10",
         "vscode-languageserver": "^10.0.1",
@@ -11151,21 +11160,15 @@
         "tsx": "^4.22.4"
       }
     },
-    "packages/language-server/node_modules/htmljs-parser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.12.1.tgz",
-      "integrity": "sha512-QnHLg5SWqoH5o8MD4iOWJFtdKSS2lXxtNgyznFXvEeeCK0CTi6URdYtFGkFGDANdq8RZzkuc91KaBgLx2WAhSA==",
-      "license": "MIT"
-    },
     "packages/language-tools": {
       "name": "@marko/language-tools",
       "version": "2.6.3",
       "license": "MIT",
       "dependencies": {
         "@luxass/strip-json-comments": "^1.4.0",
-        "@marko/compiler": "^5.39.66",
+        "@marko/compiler": "^5.41.0",
         "htmljs-parser": "^5.12.1",
-        "relative-import-path": "^1.0.0"
+        "relative-import-path": "^1.0.1"
       },
       "devDependencies": {
         "@types/babel__code-frame": "^7.27.0",
@@ -11174,12 +11177,6 @@
         "mitata": "^1.0.34",
         "tsx": "^4.22.4"
       }
-    },
-    "packages/language-tools/node_modules/htmljs-parser": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.12.1.tgz",
-      "integrity": "sha512-QnHLg5SWqoH5o8MD4iOWJFtdKSS2lXxtNgyznFXvEeeCK0CTi6URdYtFGkFGDANdq8RZzkuc91KaBgLx2WAhSA==",
-      "license": "MIT"
     },
     "packages/ts-plugin": {
       "name": "@marko/ts-plugin",
@@ -11199,7 +11196,7 @@
       "license": "MIT",
       "dependencies": {
         "@luxass/strip-json-comments": "^1.4.0",
-        "@marko/compiler": "^5.39.66",
+        "@marko/compiler": "^5.41.0",
         "@marko/language-tools": "^2.6.3",
         "arg": "^5.0.2",
         "kleur": "^4.1.5",

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@luxass/strip-json-comments": "^1.4.0",
-    "@marko/compiler": "^5.39.66",
+    "@marko/compiler": "^5.41.0",
     "@marko/language-tools": "^2.6.3",
     "axe-core": "^4.12.1",
     "htmljs-parser": "^5.12.1",
@@ -52,7 +52,7 @@
     "marko": "^5.39.11",
     "prettier": "^3.8.4",
     "prettier-plugin-marko": "^4.0.9",
-    "relative-import-path": "^1.0.0",
+    "relative-import-path": "^1.0.1",
     "typescript": "^6.0.3",
     "vscode-css-languageservice": "^6.3.10",
     "vscode-languageserver": "^10.0.1",

--- a/packages/language-tools/package.json
+++ b/packages/language-tools/package.json
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@luxass/strip-json-comments": "^1.4.0",
-    "@marko/compiler": "^5.39.66",
+    "@marko/compiler": "^5.41.0",
     "htmljs-parser": "^5.12.1",
-    "relative-import-path": "^1.0.0"
+    "relative-import-path": "^1.0.1"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.27.0",

--- a/packages/language-tools/src/extractors/script/index.ts
+++ b/packages/language-tools/src/extractors/script/index.ts
@@ -1,5 +1,6 @@
 import type { types as t } from "@marko/compiler";
 import type { TagDefinition, TaglibLookup } from "@marko/compiler/babel-utils";
+import path from "path";
 import { relativeImportPath } from "relative-import-path";
 import type TS from "typescript/lib/tsserverlibrary";
 
@@ -52,6 +53,7 @@ const REG_OBJECT_PROPERTY = /^[_$a-z][_$a-z0-9]*$/i;
 // Match https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path- and https://www.typescriptlang.org/docs/handbook/intro-to-js-ts.html#ts-check
 const REG_COMMENT_PRAGMA = /\/\/(?:\s*@ts-|\/\s*<)/y;
 const REG_TAG_NAME_IDENTIFIER = /^[A-Z][a-zA-Z0-9_$]+$/;
+const REG_NODE_MODULES = /[\\/]node_modules[\\/]/;
 const IF_TAG_ALTERNATES = new WeakMap<IfTag, IfTagAlternates>();
 const TAG_ID = new WeakMap<Node.Tag, number>();
 const RENDER_VAR = new WeakMap<Node.Tag, string>();
@@ -2182,12 +2184,42 @@ function isValueAttribute(
 
 function resolveTagImport(from: string, def: TagDefinition | undefined) {
   const filename = resolveTagFile(def);
-  if (filename) {
-    // `from` is parsed.filename which is already normalized, but the taglib
-    // provided path must use native separators too or relativeImportPath
-    // falls back to returning the absolute path.
-    return from ? relativeImportPath(from, normalizePath(filename)) : filename;
-  }
+  if (!def || !filename) return;
+  if (!from) return filename;
+
+  // `from` is parsed.filename which is already normalized, but the taglib
+  // provided path must use native separators too or relativeImportPath
+  // falls back to returning the absolute path.
+  const to = normalizePath(filename);
+  return packageImportPath(from, def, to) || relativeImportPath(from, to);
+}
+
+/**
+ * A tag installed into `node_modules` is imported through the name its package was
+ * resolved by, since its path is a realpath which may not be importable at all.
+ */
+function packageImportPath(from: string, def: TagDefinition, filename: string) {
+  const { packageName, packageRoot } = def;
+  if (!packageName || !packageRoot || !REG_NODE_MODULES.test(filename)) return;
+
+  // Within the package we stay relative, both because it always resolves and
+  // because a self reference would only work if the package exports the tag.
+  if (!isWithin(packageRoot, filename) || isWithin(packageRoot, from)) return;
+
+  const subPath = path.relative(packageRoot, filename);
+  return `${packageName}/${subPath.split(path.sep).join("/")}`;
+}
+
+function isWithin(dir: string, filename: string) {
+  const rel = path.relative(dir, filename);
+  // `path.relative` walks out of the dir with `..`, or returns an absolute path
+  // when it cannot relate the two at all, eg across windows drives.
+  return (
+    !!rel &&
+    rel !== ".." &&
+    !rel.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(rel)
+  );
 }
 
 function resolveTagFile(def: TagDefinition | undefined): string | undefined {

--- a/packages/type-check/package.json
+++ b/packages/type-check/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@luxass/strip-json-comments": "^1.4.0",
-    "@marko/compiler": "^5.39.66",
+    "@marko/compiler": "^5.41.0",
     "@marko/language-tools": "^2.6.3",
     "arg": "^5.0.2",
     "kleur": "^4.1.5",


### PR DESCRIPTION
Taglibs are discovered by resolving `<name>/marko.json`, which realpaths the result. For a package manager with a virtual store (eg pnpm) that realpath is not importable, so the extracted `import(...)` for a tag pointed into `node_modules/.pnpm/...` and failed to resolve. The tag then typed as `any`, which silently degraded two way bindings to read only.

Tags now use the name their taglib was resolved by, from `packageName` on the tag definition. Requires https://github.com/marko-js/marko/pull/3418, and falls back to the current behaviour without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)