### PR TITLE
Add agent-feedback setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,7 @@ Uses `@changesets/cli` for versioning and releases:
 - `dist/` is the build output directory for all packages (gitignored)
 - `package-lock.json` is the lockfile (npm workspaces, not yarn/pnpm)
 - Node 22+ required for development (CI tests on 22 and 24)
+
+## Agent feedback
+
+Anything actionable but out of scope for the current task — a suspected bug, cleanup, a perf/size win, tooling friction, or code that was confusing — must be recorded in [`agent-feedback/`](agent-feedback/README.md) before finishing. Don't silently drop it, and don't fix it inside an unrelated diff.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/agent-feedback/README.md
+++ b/agent-feedback/README.md
@@ -1,0 +1,39 @@
+# Agent Feedback
+
+Actionable observations that were **out of scope for the task that surfaced them**. If something is in scope, fix it instead. Do not expand a task's diff to fix issues recorded here.
+
+## When to add an entry
+
+While working on any task, record anything a future contributor should act on:
+
+- a suspected bug you couldn't pursue → `bugs.md`
+- duplication, dead code, inconsistency, refactor opportunities → `cleanup.md`
+- runtime speed or bundle size opportunities → `perf.md`
+- friction in builds, tests, tooling, or repo workflows → `dx.md`
+- code or docs that were confusing, and what would have clarified them → `unclear.md`
+
+## Rules
+
+1. **Search the category file first.** If an entry already covers it, don't duplicate; append a corroborating sentence only if you have new information.
+2. **Be self-contained.** Include enough detail (paths, symbols, reasoning) that someone can act without re-discovering your analysis. Never reference "my earlier analysis" or conversation context.
+3. **Cite by stable symbol, not line number.** Line numbers rot with the next edit; anchor the primary citation to the nearest enclosing stable symbol (exported function, class, variable, or a heading for docs). A line number may appear in the body as a secondary hint.
+4. **Append to the end** of the category file.
+5. Entries are **removed when resolved** (delete, don't mark done; git history is the archive).
+6. **Verify before recording.** A guess is not feedback.
+
+## Resolving a "won't fix" item
+
+When a maintainer has explicitly deemed an item "won't fix" / "not worth it", resolve it by adding a brief inline comment at the code site that captures the decision (so it is not re-filed), then remove the entry. Only on such an explicit call — never on your own initiative.
+
+## Entry format
+
+```md
+## <one-line imperative summary>
+
+`<primary/file/path.ts>` › `<nearestStableSymbol>` | 2026-07-02 | impact:<low|med|high> | effort:<low|med|high>
+
+<2–6 sentences: the problem, why it matters, and a concrete suggested direction,
+ending with the check that re-verifies the claim (a command, input, or
+observation). Cut evidence beyond what a fixer needs to act; further detail is
+re-derived from the citation. Additional file paths inline as needed.>
+```

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1,0 +1,3 @@
+# Suspected Bugs
+
+Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -1,0 +1,3 @@
+# Cleanup
+
+Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -1,0 +1,3 @@
+# Developer Experience
+
+Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -1,0 +1,3 @@
+# Performance
+
+Runtime speed and bundle size opportunities. Format and rules: [README.md](README.md).

--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -1,0 +1,3 @@
+# Unclear Code & Docs
+
+Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).


### PR DESCRIPTION
Adds the `agent-feedback/` directory (README + bugs/cleanup/dx/perf/unclear category files) and references it from AGENTS.md, matching the setup in the marko repo.