### PR TITLE
fix: stop leaking the internal "~api" export into .d.marko output

### DIFF
--- a/.changeset/dts-api-export.md
+++ b/.changeset/dts-api-export.md
@@ -1,0 +1,9 @@
+---
+"@marko/language-server": patch
+"@marko/language-tools": patch
+"@marko/ts-plugin": patch
+"@marko/type-check": patch
+"marko-vscode": patch
+---
+
+Stop leaking the internal `"~api"` export into generated `.d.marko` files.

--- a/packages/language-tools/src/extractors/script/index.ts
+++ b/packages/language-tools/src/extractors/script/index.ts
@@ -41,6 +41,13 @@ const SEP_SPACE = " ";
 const SEP_COMMA_SPACE = ", ";
 const SEP_COMMA_NEW_LINE = ",\n";
 const VAR_LOCAL_PREFIX = "__marko_internal_";
+/**
+ * The `const` holding the resolved runtime api and the name it is exported as.
+ * Consumers of the extracted output (eg the `.d.marko` printer) need to
+ * recognize these to strip the internal export back out.
+ */
+export const INTERNAL_API_VAR = `${VAR_LOCAL_PREFIX}api`;
+export const INTERNAL_API_EXPORT_NAME = "~api";
 const VAR_SHARED_PREFIX = `Marko._.`;
 const ATTR_UNNAMED = "value";
 const REG_EXT = /(?<=[/\\][^/\\]+)\.[^.]+$/;
@@ -433,7 +440,7 @@ function ${templateName}() {\n`);
     )}<${internalInput}, Marko.Directives & Input${typeArgsStr}>) => (${varShared(
       "ReturnWithScope",
     )}<${internalInput}, ${returnTypeStr}>)`;
-    const apiVar = varLocal("api");
+    const apiVar = INTERNAL_API_VAR;
     const templateOverrideClass = `${templateBaseClass}<{${
       this.#runtimeTypes
         ? getRuntimeOverrides(
@@ -469,7 +476,7 @@ function ${templateName}() {\n`);
       // `.ts` and `.js` extractions; it still surfaces the api as a
       // `"tags"`/`"class"` string literal.
       this.#extractor.write(
-        `const ${apiVar} = "${this.#api}";\nexport { ${apiVar} as "~api" };\n`,
+        `const ${apiVar} = "${this.#api}";\nexport { ${apiVar} as "${INTERNAL_API_EXPORT_NAME}" };\n`,
       );
     }
 

--- a/packages/language-tools/src/processors/marko.ts
+++ b/packages/language-tools/src/processors/marko.ts
@@ -2,7 +2,12 @@ import type { Config, types as t } from "@marko/compiler";
 import path from "path";
 import type ts from "typescript/lib/tsserverlibrary";
 
-import { extractScript, ScriptLang } from "../extractors/script";
+import {
+  extractScript,
+  INTERNAL_API_EXPORT_NAME,
+  INTERNAL_API_VAR,
+  ScriptLang,
+} from "../extractors/script";
 import { parse } from "../parser";
 import * as Project from "../util/project";
 import type { ProcessorConfig } from ".";
@@ -141,7 +146,7 @@ const markoProcessor: ProcessorConfig = {
             // Matches `export default ...`.
             defaultExport = statement;
             defaultExportId = ts.isIdentifier(statement.expression)
-              ? (statement.expression.escapedText as string)
+              ? statement.expression.text
               : undefined;
           } else if (
             ts.isClassDeclaration(statement) &&
@@ -167,6 +172,8 @@ const markoProcessor: ProcessorConfig = {
             isImportComponentType(statement) || // skips the generated `import type Component from "..."`.
             isExportEmptyInputType(statement) || // skips empty exported Input, eg `export type Input = {}` or `export interface Input {}`.
             isExportInputTypeAsComponentInput(statement) || // skips outputting `export type Input = Component["input"]` since it's inferred.
+            isInternalApiVar(statement) || // skips the generated `const __marko_internal_api = "..."`.
+            isExportInternalApi(statement) || // skips the generated `export { __marko_internal_api as "~api" }`.
             (defaultExportId && // If the `export default` was an identifier, we also remove the variable that declared the identifier.
               isVariableStatementForName(statement, defaultExportId))
           ) {
@@ -290,6 +297,36 @@ const markoProcessor: ProcessorConfig = {
       );
     }
 
+    // The `"~api"` export is re-derived whenever the emitted `.d.marko` is
+    // itself extracted, so both it and the `const` backing it are internal to
+    // the extracted script and must not be printed into the declaration file.
+    function isInternalApiVar(statement: ts.Statement) {
+      return isVariableStatementForName(statement, INTERNAL_API_VAR);
+    }
+
+    function isExportInternalApi(statement: ts.Statement) {
+      if (
+        !ts.isExportDeclaration(statement) ||
+        statement.moduleSpecifier || // the generated export names a local `const`, so it has no source.
+        !statement.exportClause ||
+        !ts.isNamedExports(statement.exportClause) ||
+        statement.exportClause.elements.length !== 1
+      ) {
+        return false;
+      }
+
+      // Matched on both names so a source `export { something as "~api" }` is
+      // left alone.
+      const [{ name, propertyName }] = statement.exportClause.elements;
+      return (
+        ts.isStringLiteral(name) &&
+        name.text === INTERNAL_API_EXPORT_NAME &&
+        !!propertyName &&
+        ts.isIdentifier(propertyName) &&
+        propertyName.text === INTERNAL_API_VAR
+      );
+    }
+
     function isExportComponentType(statement: ts.Statement) {
       if (ts.isExportDeclaration(statement)) {
         return (
@@ -309,7 +346,9 @@ const markoProcessor: ProcessorConfig = {
     function isVariableStatementForName(statement: ts.Statement, name: string) {
       if (ts.isVariableStatement(statement)) {
         for (const decl of statement.declarationList.declarations) {
-          if (ts.isIdentifier(decl.name) && decl.name.escapedText === name) {
+          // `text` rather than `escapedText` since TypeScript escapes leading
+          // double underscores (as in `__marko_internal_api`) in the latter.
+          if (ts.isIdentifier(decl.name) && decl.name.text === name) {
             return true;
           }
         }

--- a/packages/type-check/.mocharc.json
+++ b/packages/type-check/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "timeout": 30000,
+  "enable-source-maps": true,
+  "watchFiles": ["src/**/*.@(ts|marko)", "!**/__snapshots__/**"],
+  "require": ["tsx", "mocha-snap"]
+}

--- a/packages/type-check/package.json
+++ b/packages/type-check/package.json
@@ -26,7 +26,9 @@
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
-    "build": "tsx build.mts"
+    "build": "tsx build.mts",
+    "test": "mocha './src/**/__tests__/*.test.ts'",
+    "test:update": "mocha './src/**/__tests__/*.test.ts' --update"
   },
   "dependencies": {
     "@luxass/strip-json-comments": "^1.4.0",

--- a/packages/type-check/src/__tests__/emit.test.ts
+++ b/packages/type-check/src/__tests__/emit.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+
+import { Project } from "@marko/language-tools";
+import fs from "fs";
+import snapshot from "mocha-snap";
+import path from "path";
+
+import run, { Display } from "../run";
+
+Project.setDefaultTypePaths({
+  internalTypesFile:
+    require.resolve("@marko/language-tools/marko.internal.d.ts"),
+  markoTypesFile: require.resolve("marko/index.d.ts"),
+});
+
+const FIXTURE_DIR = path.join(__dirname, "fixtures");
+
+for (const fixture of fs.readdirSync(FIXTURE_DIR)) {
+  const fixtureDir = path.join(FIXTURE_DIR, fixture);
+  if (!fs.statSync(fixtureDir).isDirectory()) continue;
+
+  describe(`emit ${fixture}`, () => {
+    const outDir = path.join(fixtureDir, "dist");
+    let emitted: string[];
+
+    before(() => {
+      // The previous run's output (including its `.tsbuildinfo`) would make the
+      // solution builder consider the project up to date and skip emitting.
+      fs.rmSync(outDir, { recursive: true, force: true });
+      assert.equal(
+        typeCheck(path.join(fixtureDir, "tsconfig.json")),
+        "",
+        "expected the fixture to type check cleanly",
+      );
+      emitted = findFiles(outDir, ".d.marko");
+      assert.ok(emitted.length, "expected `.d.marko` files to be emitted");
+    });
+
+    it("emits declaration files", async () => {
+      for (const file of emitted) {
+        await snapshot(fs.readFileSync(file, "utf-8"), {
+          file: path.relative(outDir, file),
+          dir: fixtureDir,
+        });
+      }
+    });
+
+    it("emits declaration files that type check", () => {
+      // A `.d.marko` is itself a Marko file, so anything internal to the
+      // extracted script that leaks into it shows up here as a syntax or type
+      // error.
+      const checkDir = path.join(outDir, "__recheck__");
+      const checkSrcDir = path.join(checkDir, "src");
+      fs.mkdirSync(checkSrcDir, { recursive: true });
+      fs.copyFileSync(
+        path.join(fixtureDir, "tsconfig.json"),
+        path.join(checkDir, "tsconfig.json"),
+      );
+
+      for (const file of emitted) {
+        fs.copyFileSync(file, path.join(checkSrcDir, path.basename(file)));
+      }
+
+      assert.equal(typeCheck(path.join(checkDir, "tsconfig.json")), "");
+    });
+  });
+}
+
+/**
+ * Runs the type check for a project, returning whatever it reported. `run`
+ * writes its report to stdout and the process exit code, neither of which a
+ * test should inherit.
+ */
+function typeCheck(project: string) {
+  const { log } = console;
+  const { exitCode } = process;
+  let out = "";
+  console.log = (msg: string) => {
+    out += msg;
+  };
+
+  try {
+    run({ project, display: Display.condensed });
+  } finally {
+    console.log = log;
+    process.exitCode = exitCode;
+  }
+
+  return out.trim();
+}
+
+function findFiles(dir: string, ext: string) {
+  const files: string[] = [];
+  if (fs.existsSync(dir)) {
+    for (const entry of fs.readdirSync(dir)) {
+      const file = path.join(dir, entry);
+      if (fs.statSync(file).isDirectory()) {
+        files.push(...findFiles(file, ext));
+      } else if (entry.endsWith(ext)) {
+        files.push(file);
+      }
+    }
+  }
+
+  return files.sort();
+}

--- a/packages/type-check/src/__tests__/fixtures/emit/__snapshots__/emits-declaration-files.expected/counter.d.marko
+++ b/packages/type-check/src/__tests__/fixtures/emit/__snapshots__/emits-declaration-files.expected/counter.d.marko
@@ -1,0 +1,8 @@
+export interface Input {
+    start: number;
+}
+class {
+    declare count: number;
+    onCreate(input: Input): void { return 1 as any; }
+    increment(): void { return 1 as any; }
+}

--- a/packages/type-check/src/__tests__/fixtures/emit/__snapshots__/emits-declaration-files.expected/greet.d.marko
+++ b/packages/type-check/src/__tests__/fixtures/emit/__snapshots__/emits-declaration-files.expected/greet.d.marko
@@ -1,0 +1,4 @@
+export interface Input {
+    name: string;
+}
+<return = (1 as any as { count: number; })/>

--- a/packages/type-check/src/__tests__/fixtures/emit/__snapshots__/emits-declaration-files.expected/static.d.marko
+++ b/packages/type-check/src/__tests__/fixtures/emit/__snapshots__/emits-declaration-files.expected/static.d.marko
@@ -1,0 +1,4 @@
+export type Size = "sm" | "lg";
+export interface Input {
+    size?: Size;
+}

--- a/packages/type-check/src/__tests__/fixtures/emit/src/counter.marko
+++ b/packages/type-check/src/__tests__/fixtures/emit/src/counter.marko
@@ -1,0 +1,15 @@
+export interface Input {
+  start: number;
+}
+
+class {
+  declare count: number;
+  onCreate(input: Input) {
+    this.count = input.start;
+  }
+  increment() {
+    this.count++;
+  }
+}
+
+<button on-click("increment")>${input.start}</button>

--- a/packages/type-check/src/__tests__/fixtures/emit/src/greet.marko
+++ b/packages/type-check/src/__tests__/fixtures/emit/src/greet.marko
@@ -1,0 +1,7 @@
+export interface Input {
+  name: string;
+}
+
+<let/count=0/>
+<div>Hello ${input.name} ${count}</div>
+<return={ count }/>

--- a/packages/type-check/src/__tests__/fixtures/emit/src/static.marko
+++ b/packages/type-check/src/__tests__/fixtures/emit/src/static.marko
@@ -1,0 +1,7 @@
+export type Size = "sm" | "lg";
+
+export interface Input {
+  size?: Size;
+}
+
+<div class=`box-${input.size || "sm"}`/>

--- a/packages/type-check/src/__tests__/fixtures/emit/tsconfig.json
+++ b/packages/type-check/src/__tests__/fixtures/emit/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    // Keeps the emit (and so the snapshots) to declarations rather than also
+    // writing the compiled template output.
+    "emitDeclarationOnly": true,
+    // Must live in `dist` so the test wiping `dist` fully resets the build.
+    // Left at its default it sits beside this file, and the solution builder
+    // considers the project up to date and emits nothing on the next run.
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
The standalone `"~api"` export added to the extracted script in e986bcb3 was being copied into generated `.d.marko` files, which came out as `static declare const __marko_internal_api = "class";` plus the export itself. The `.d.marko` printer now skips it and the `const` backing it — matching the generated export's local name and rejecting re-exports, so a source `export { something as "~api" }` is left alone. The api is re-derived whenever the `.d.marko` is extracted, so nothing is lost.

Also fixes `isVariableStatementForName` comparing `escapedText`, which TypeScript prefixes with an extra underscore for `__`-prefixed identifiers.

Adds the coverage that was missing: `@marko/type-check` now snapshots every emitted `.d.marko` for a fixture project and type checks the emitted files as Marko sources, so leaked internals fail the build.