### PR TITLE
agent-feedback: tag variable typing and nested diagnostic information

### DIFF
--- a/agent-feedback/items/2026-08-20-hoisted-tag-var-never.md
+++ b/agent-feedback/items/2026-08-20-hoisted-tag-var-never.md
@@ -1,0 +1,14 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/language-tools/marko.internal.d.ts › hoist
+---
+
+<!-- cspell:ignore feild -->
+
+# Type a tag variable read above its declaring tag instead of collapsing it to `never`
+
+`#writeProgram` emits `const x = Marko._.hoist(() => __marko_internal_hoist__x)` for every program-level tag variable, and `hoist` is declared `<T>(value: () => T) => T extends () => infer R ? T & Iterable<R> : never`, so every hoisted variable whose value is not itself a function types as `never`; only reads below the declaring tag pick up the shadowing `const` with the real type. `<div class=styles.field>` written above `<style/styles>.field{...}</style>` therefore reports `Property 'field' does not exist on type 'never'` on markup the compiler lowers to the same `_attr_class(styles.field)` it emits for the working order, and the typo `styles.feild` reports the identical message, so the check cannot separate right from wrong -- put the `<style>` tag first and the correct name passes while the typo becomes a `TS2551` naming `field`. The same collapse rejects the legal handler spelling `<button onClick() { n() }>` above `<let/n=1>`, which compiles to `$n_getter($scope)()`, with `Type 'never' has no call signatures`. A hoisted tag variable's runtime binding is a getter, so its type is `() => T`; a `<style/name>` var is a plain module binding the bundler injects and should not go through `hoist` at all.
+
+Check: type-check `<div class=styles.field>x</div>` followed by `<style/styles>.field{color:red}</style>`; `mtc` reports `TS2339 Property 'field' does not exist on type 'never'` today and should report nothing, as it already does when the `<style>` tag is written first.

--- a/agent-feedback/items/2026-08-20-related-info-reported-as-error.md
+++ b/agent-feedback/items/2026-08-20-related-info-reported-as-error.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/type-check/src/run.ts › reportRelatedDiagnostics
+---
+
+# Nest a diagnostic's related information under its parent instead of re-reporting it as a top-level error
+
+`reportRelatedDiagnostics` feeds every `diag.relatedInformation` entry back through `reportDiagnostic`, so each one prints as a standalone diagnostic with its own `file:line:col - <category> TS<code>` header and code frame, detached from the error it explains. Several of TypeScript's related-information codes carry category `Error` -- `TS6236` "Arguments for the rest parameter '...' were not provided" among them -- so one mistake in a `.marko` file prints two `error TS` lines, the second anchored in a file the user does not own: `Run.href("/venues/$venueId")` with the params argument omitted yields the user-file `TS2554` plus a top-level `node_modules/@marko/run/dist/runtime/types.d.ts - error TS6236`. `tsc --pretty` prints the same related information indented under its parent with no category and no code and then reports `Found 2 errors`, so a reader or a script counting `mtc`'s `error TS` lines over-counts and gets sent into `node_modules`. `--display condensed` skips related information entirely, so the two display modes disagree about how many diagnostics exist.
+
+Check: type-check a `.marko` file that calls a dependency's rest-parameter function with the rest argument omitted; `mtc` prints `node_modules/<dep>/index.d.ts:N:M - error TS6236` as a top-level entry beside the user-file `TS2554` today, and should print it indented under the `TS2554` without an `error TS` header, the way `tsc --pretty` does.


### PR DESCRIPTION
Two new items: a tag variable read above its declaring tag collapses to `never`, and a diagnostic's related information is re-reported as a top-level error rather than nesting under its parent.
